### PR TITLE
feat(ui): rewrite mission supervision dashboard

### DIFF
--- a/overlord/app.py
+++ b/overlord/app.py
@@ -10,12 +10,9 @@ from fastapi.templating import Jinja2Templates
 
 from overlord.config import Settings
 from overlord.dashboard import (
-    build_network_clusters,
+    build_supervision_view,
     format_relative_time,
     format_timestamp,
-    grouped_phase_notes,
-    pick_focus_worker,
-    worker_freshness,
 )
 from overlord.dispatcher import CodexDispatcher, DispatchLaunchError
 from overlord.models import (
@@ -236,15 +233,21 @@ def _render_dashboard(
 ) -> HTMLResponse:
     snapshot = state_store.snapshot()
     recent_commands = state_store.list_commands()
-    requested_worker_id = request.query_params.get("worker")
-    selected_worker_id = pick_focus_worker(snapshot, requested_worker_id)
-    selected_worker = (
-        state_store.get_worker(selected_worker_id) if selected_worker_id is not None else None
-    )
-    worker_states = {
-        worker.worker_id: worker_freshness(worker.updated_at)
+    worker_details = {
+        worker.worker_id: state_store.get_worker(worker.worker_id)
         for worker in snapshot.workers
     }
+    supervision = build_supervision_view(
+        snapshot,
+        worker_details,
+        recent_commands,
+        requested_worker_id=request.query_params.get("worker"),
+        requested_mission_id=request.query_params.get("mission"),
+        search_query=request.query_params.get("q", ""),
+        current_view=request.query_params.get("view", "missions"),
+        saved_view=request.query_params.get("saved_view", "all-active"),
+    )
+    selected_worker = supervision["selected_worker"]
     report_defaults = {
         "worker_id": selected_worker.worker_id if selected_worker else "",
         "current_phase": (
@@ -281,16 +284,9 @@ def _render_dashboard(
             "snapshot": snapshot,
             "recent_commands": recent_commands,
             "selected_worker": selected_worker,
-            "selected_worker_id": selected_worker_id,
-            "selected_phase_notes": (
-                grouped_phase_notes(selected_worker) if selected_worker is not None else []
-            ),
-            "worker_states": worker_states,
-            "network_clusters": build_network_clusters(
-                snapshot,
-                worker_states,
-                selected_worker_id,
-            ),
+            "selected_worker_id": supervision["selected_worker_id"],
+            "selected_phase_notes": supervision["selected_worker_notes"],
+            "supervision": supervision,
             "timestamp_format": format_timestamp,
             "report_status": request.query_params.get("report"),
             "report_error": request.query_params.get("error"),

--- a/overlord/dashboard.py
+++ b/overlord/dashboard.py
@@ -1,40 +1,80 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
 
-from overlord.models import DashboardSnapshot, PHASE_ORDER, WorkerDetail, WorkerPhase
+from overlord.models import (
+    ConflictRecord,
+    DashboardSnapshot,
+    OperatorCommandRecord,
+    PHASE_ORDER,
+    WorkerDetail,
+    WorkerPhase,
+)
 
 
-AGING_AFTER_SECONDS = 8 * 60
+QUIET_AFTER_SECONDS = 5 * 60
 STALE_AFTER_SECONDS = 20 * 60
 
-PHASE_THEATER_LABELS = {
-    WorkerPhase.ASSIGNED: "reserve units waiting for first movement",
-    WorkerPhase.SCOUTING: "recon lines reading repo terrain",
-    WorkerPhase.PLANNED: "attack lanes with a defined irreversible step",
-    WorkerPhase.IMPLEMENTING: "active pushes modifying the battlefield",
-    WorkerPhase.VALIDATING: "verification batteries checking the line",
-    WorkerPhase.BLOCKED: "contested sectors calling for operator attention",
-    WorkerPhase.HANDOFF_READY: "units holding position for handoff",
-    WorkerPhase.TERMINAL: "completed sorties retained for record",
+MISSION_VIEWS = ["missions", "board", "fanout", "dispatches", "conflicts", "workers"]
+SAVED_VIEW_DEFS = [
+    ("all-active", "All Active"),
+    ("needs-attention", "Needs Attention"),
+    ("merge-work", "Merge Work"),
+    ("stale-only", "Stale Only"),
+    ("solo-workers", "Solo Workers"),
+]
+MERGE_ORDER = [
+    "no_branch",
+    "branch_active",
+    "pr_open",
+    "changes_requested",
+    "approved",
+    "merged_to_main",
+    "synced_locally",
+]
+MERGE_LABELS = {
+    "no_branch": "no branch",
+    "branch_active": "branch active",
+    "pr_open": "pr open",
+    "changes_requested": "changes requested",
+    "approved": "approved",
+    "merged_to_main": "merged to main",
+    "synced_locally": "synced locally",
+}
+PHASE_PRIORITY = {
+    WorkerPhase.BLOCKED: 0,
+    WorkerPhase.HANDOFF_READY: 1,
+    WorkerPhase.VALIDATING: 2,
+    WorkerPhase.IMPLEMENTING: 3,
+    WorkerPhase.PLANNED: 4,
+    WorkerPhase.SCOUTING: 5,
+    WorkerPhase.ASSIGNED: 6,
+    WorkerPhase.TERMINAL: 7,
+}
+SUPERVISION_PHASE_LABELS = {
+    WorkerPhase.ASSIGNED: "assigned",
+    WorkerPhase.SCOUTING: "scouting",
+    WorkerPhase.PLANNED: "planned",
+    WorkerPhase.IMPLEMENTING: "implementing",
+    WorkerPhase.VALIDATING: "validating",
+    WorkerPhase.BLOCKED: "blocked",
+    WorkerPhase.HANDOFF_READY: "ready for review",
+    WorkerPhase.TERMINAL: "terminal",
 }
 
 
 def format_relative_time(value: datetime) -> str:
-    now = datetime.now(timezone.utc)
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    delta_seconds = int((now - value.astimezone(timezone.utc)).total_seconds())
+    delta_seconds = _age_seconds(value)
     if delta_seconds < 60:
         return "just now"
     if delta_seconds < 3600:
-        minutes = delta_seconds // 60
-        return f"{minutes}m ago"
+        return f"{delta_seconds // 60}m ago"
     if delta_seconds < 86400:
-        hours = delta_seconds // 3600
-        return f"{hours}h ago"
-    days = delta_seconds // 86400
-    return f"{days}d ago"
+        return f"{delta_seconds // 3600}h ago"
+    return f"{delta_seconds // 86400}d ago"
 
 
 def format_timestamp(value: datetime) -> str:
@@ -44,22 +84,18 @@ def format_timestamp(value: datetime) -> str:
 
 
 def worker_freshness(value: datetime) -> dict[str, str | int]:
-    now = datetime.now(timezone.utc)
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    age_seconds = max(0, int((now - value.astimezone(timezone.utc)).total_seconds()))
+    age_seconds = _age_seconds(value)
     age_minutes = age_seconds // 60
     if age_seconds >= STALE_AFTER_SECONDS:
         state = "stale"
-    elif age_seconds >= AGING_AFTER_SECONDS:
-        state = "aging"
+        label = f"stale {max(1, age_minutes)}m"
+    elif age_seconds >= QUIET_AFTER_SECONDS:
+        state = "quiet"
+        label = f"quiet {max(1, age_minutes)}m"
     else:
-        state = "fresh"
-    return {
-        "state": state,
-        "label": f"{format_relative_time(value)} update",
-        "age_minutes": age_minutes,
-    }
+        state = "active"
+        label = "active now" if age_seconds < 60 else f"active {max(1, age_minutes)}m"
+    return {"state": state, "label": label, "age_minutes": age_minutes}
 
 
 def pick_focus_worker(snapshot: DashboardSnapshot, requested_worker_id: str | None) -> str | None:
@@ -68,22 +104,11 @@ def pick_focus_worker(snapshot: DashboardSnapshot, requested_worker_id: str | No
         return requested_worker_id
     if not snapshot.workers:
         return None
-
-    priority = {
-        WorkerPhase.BLOCKED: 0,
-        WorkerPhase.HANDOFF_READY: 1,
-        WorkerPhase.VALIDATING: 2,
-        WorkerPhase.IMPLEMENTING: 3,
-        WorkerPhase.PLANNED: 4,
-        WorkerPhase.SCOUTING: 5,
-        WorkerPhase.ASSIGNED: 6,
-        WorkerPhase.TERMINAL: 7,
-    }
     ranked = sorted(
         snapshot.workers,
         key=lambda worker: (
-            priority[worker.phase],
-            worker.updated_at.timestamp() * -1,
+            PHASE_PRIORITY[worker.phase],
+            -worker.updated_at.timestamp(),
             worker.worker_id,
         ),
     )
@@ -99,32 +124,855 @@ def grouped_phase_notes(worker: WorkerDetail) -> list[dict[str, object]]:
     return grouped
 
 
-def build_network_clusters(
+def build_supervision_view(
     snapshot: DashboardSnapshot,
-    worker_states: dict[str, dict[str, str | int]],
-    selected_worker_id: str | None,
-) -> list[dict[str, object]]:
-    clusters: list[dict[str, object]] = []
-    for phase in PHASE_ORDER:
-        workers = snapshot.by_phase[phase]
-        if not workers:
-            continue
+    worker_details: dict[str, WorkerDetail],
+    recent_commands: list[OperatorCommandRecord],
+    *,
+    requested_worker_id: str | None,
+    requested_mission_id: str | None,
+    search_query: str,
+    current_view: str,
+    saved_view: str,
+) -> dict[str, Any]:
+    normalized_search = search_query.strip().lower()
+    worker_states = {
+        worker.worker_id: worker_freshness(worker.updated_at)
+        for worker in snapshot.workers
+    }
+    conflicts_by_worker = _index_conflicts(snapshot.conflicts)
+    mission_rows = _build_mission_rows(
+        snapshot,
+        worker_details,
+        recent_commands,
+        worker_states,
+        conflicts_by_worker,
+    )
+    mission_rows = _apply_search(mission_rows, normalized_search)
+    mission_rows = _apply_saved_view(mission_rows, saved_view)
+    attention_items = _build_attention_queue(mission_rows)
+    selected_worker_id = _pick_selected_worker_id(mission_rows, requested_worker_id)
+    selected_mission_id = _pick_selected_mission_id(
+        mission_rows,
+        requested_mission_id=requested_mission_id,
+        requested_worker_id=selected_worker_id,
+    )
 
-        units = [
+    for mission in mission_rows:
+        mission["selected"] = mission["id"] == selected_mission_id
+        for worker in mission["workers"]:
+            worker["selected"] = worker["worker_id"] == selected_worker_id
+
+    selected_mission = next(
+        (mission for mission in mission_rows if mission["id"] == selected_mission_id),
+        None,
+    )
+    selected_worker = (
+        worker_details[selected_worker_id] if selected_worker_id and selected_worker_id in worker_details else None
+    )
+
+    return {
+        "current_view": current_view if current_view in MISSION_VIEWS else "missions",
+        "saved_view": saved_view if saved_view in {key for key, _ in SAVED_VIEW_DEFS} else "all-active",
+        "search_query": search_query,
+        "search_active": bool(normalized_search),
+        "worker_states": worker_states,
+        "selected_worker_id": selected_worker_id,
+        "selected_worker": selected_worker,
+        "selected_worker_notes": grouped_phase_notes(selected_worker) if selected_worker else [],
+        "selected_mission_id": selected_mission_id,
+        "selected_mission": selected_mission,
+        "mission_rows": mission_rows,
+        "attention_items": attention_items,
+        "summary": _build_summary(mission_rows, attention_items),
+        "mission_board": _build_mission_board(mission_rows),
+        "fanout_clusters": _build_fanout_clusters(mission_rows),
+        "dispatch_rows": _build_dispatch_rows(recent_commands, mission_rows),
+        "conflict_groups": _build_conflict_groups(mission_rows),
+        "worker_rows": _build_worker_rows(mission_rows),
+        "saved_views": [
+            {"key": key, "label": label, "selected": key == saved_view}
+            for key, label in SAVED_VIEW_DEFS
+        ],
+        "view_tabs": [
+            {"key": key, "label": _titleize(key), "selected": key == current_view}
+            for key in MISSION_VIEWS
+        ],
+    }
+
+
+def _build_mission_rows(
+    snapshot: DashboardSnapshot,
+    worker_details: dict[str, WorkerDetail],
+    recent_commands: list[OperatorCommandRecord],
+    worker_states: dict[str, dict[str, str | int]],
+    conflicts_by_worker: dict[str, list[ConflictRecord]],
+) -> list[dict[str, Any]]:
+    command_groups: dict[tuple[str, str], list[OperatorCommandRecord]] = defaultdict(list)
+    for command in recent_commands:
+        key = (command.repo_path, command.branch_hint or command.general_worker_id)
+        command_groups[key].append(command)
+
+    remaining_workers = {worker.worker_id: worker for worker in snapshot.workers}
+    missions: list[dict[str, Any]] = []
+
+    for key, commands in sorted(
+        command_groups.items(),
+        key=lambda item: max(command.created_at for command in item[1]),
+        reverse=True,
+    ):
+        repo_path, branch_or_owner = key
+        latest_command = max(commands, key=lambda command: (command.created_at, command.id))
+        matched_workers = []
+        for worker in list(remaining_workers.values()):
+            if worker.repo_path != repo_path:
+                continue
+            if latest_command.branch_hint:
+                if worker.branch == latest_command.branch_hint:
+                    matched_workers.append(worker)
+            elif worker.branch == branch_or_owner or worker.worker_id.startswith(branch_or_owner):
+                matched_workers.append(worker)
+        for worker in matched_workers:
+            remaining_workers.pop(worker.worker_id, None)
+        missions.append(
+            _build_mission(
+                workers=matched_workers,
+                worker_details=worker_details,
+                commands=sorted(commands, key=lambda command: (command.created_at, command.id), reverse=True),
+                worker_states=worker_states,
+                conflicts_by_worker=conflicts_by_worker,
+                seed_repo=repo_path,
+                owner_hint=latest_command.general_worker_id,
+                branch_hint=latest_command.branch_hint,
+                goal_hint=latest_command.operator_instruction,
+            )
+        )
+
+    repo_branch_groups: dict[tuple[str, str], list[Any]] = defaultdict(list)
+    solo_workers: list[Any] = []
+    for worker in remaining_workers.values():
+        if worker.branch:
+            repo_branch_groups[(worker.repo_path, worker.branch)].append(worker)
+        else:
+            solo_workers.append(worker)
+
+    for (repo_path, branch), workers in sorted(
+        repo_branch_groups.items(),
+        key=lambda item: max(worker.updated_at for worker in item[1]),
+        reverse=True,
+    ):
+        missions.append(
+            _build_mission(
+                workers=workers,
+                worker_details=worker_details,
+                commands=[],
+                worker_states=worker_states,
+                conflicts_by_worker=conflicts_by_worker,
+                seed_repo=repo_path,
+                owner_hint=None,
+                branch_hint=branch,
+                goal_hint=None,
+            )
+        )
+
+    for worker in sorted(solo_workers, key=lambda item: item.updated_at, reverse=True):
+        missions.append(
+            _build_mission(
+                workers=[worker],
+                worker_details=worker_details,
+                commands=[],
+                worker_states=worker_states,
+                conflicts_by_worker=conflicts_by_worker,
+                seed_repo=worker.repo_path,
+                owner_hint=worker.worker_id,
+                branch_hint=worker.branch,
+                goal_hint=None,
+            )
+        )
+
+    return sorted(
+        missions,
+        key=lambda mission: (
+            mission["attention_rank"],
+            -mission["latest_event_at"].timestamp(),
+            mission["repo_name"],
+            mission["id"],
+        ),
+    )
+
+
+def _build_mission(
+    *,
+    workers: list[Any],
+    worker_details: dict[str, WorkerDetail],
+    commands: list[OperatorCommandRecord],
+    worker_states: dict[str, dict[str, str | int]],
+    conflicts_by_worker: dict[str, list[ConflictRecord]],
+    seed_repo: str,
+    owner_hint: str | None,
+    branch_hint: str | None,
+    goal_hint: str | None,
+) -> dict[str, Any]:
+    worker_dicts: list[dict[str, Any]] = []
+    event_candidates: list[tuple[datetime, str, str, str | None]] = []
+    worker_ids = []
+    conflict_index: dict[tuple[str, str], dict[str, Any]] = {}
+    merge_counts = {state: 0 for state in MERGE_ORDER}
+
+    for worker in sorted(
+        workers,
+        key=lambda item: (PHASE_PRIORITY[item.phase], -item.updated_at.timestamp(), item.worker_id),
+    ):
+        detail = worker_details[worker.worker_id]
+        freshness = worker_states[worker.worker_id]
+        merge_state = _infer_merge_state(detail)
+        merge_counts[merge_state] += 1
+        worker_ids.append(worker.worker_id)
+        worker_dicts.append(
             {
-                "worker": worker,
-                "freshness": worker_states[worker.worker_id],
-                "selected": worker.worker_id == selected_worker_id,
+                "worker_id": worker.worker_id,
+                "phase": worker.phase,
+                "phase_label": SUPERVISION_PHASE_LABELS[worker.phase],
+                "status_line": worker.status_line,
+                "repo_path": worker.repo_path,
+                "branch": worker.branch,
+                "worktree": worker.worktree,
+                "owned_artifact": worker.owned_artifact,
+                "next_irreversible_step": worker.next_irreversible_step,
+                "blocker": worker.blocker,
+                "pr_url": worker.pr_url,
+                "updated_at": worker.updated_at,
+                "updated_label": freshness["label"],
+                "freshness_state": freshness["state"],
+                "merge_state": merge_state,
+                "merge_label": MERGE_LABELS[merge_state],
+                "timeline_count": len(detail.transitions),
+                "selected": False,
             }
-            for worker in workers
-        ]
+        )
+        event_candidates.append(
+            (
+                worker.updated_at,
+                "worker",
+                f"{worker.worker_id} {worker.phase.value}",
+                worker.worker_id,
+            )
+        )
+        for conflict in conflicts_by_worker.get(worker.worker_id, []):
+            entry = conflict_index.setdefault(
+                (conflict.field, conflict.value),
+                {
+                    "field": conflict.field,
+                    "value": conflict.value,
+                    "worker_ids": set(),
+                },
+            )
+            entry["worker_ids"].update(conflict.worker_ids)
+
+    for command in commands:
+        event_candidates.append(
+            (
+                command.created_at,
+                "dispatch",
+                f"dispatched {command.general_worker_id}",
+                None,
+            )
+        )
+
+    latest_event_at = max((item[0] for item in event_candidates), default=datetime.now(timezone.utc))
+    focus_worker = _pick_focus_worker_dict(worker_dicts)
+    blocked_workers = sum(1 for worker in worker_dicts if worker["phase"] == WorkerPhase.BLOCKED)
+    quiet_workers = sum(1 for worker in worker_dicts if worker["freshness_state"] == "quiet")
+    stale_workers = sum(1 for worker in worker_dicts if worker["freshness_state"] == "stale")
+    ready_workers = sum(1 for worker in worker_dicts if worker["phase"] == WorkerPhase.HANDOFF_READY)
+    active_workers = sum(1 for worker in worker_dicts if worker["phase"] != WorkerPhase.TERMINAL)
+
+    conflict_records = []
+    cross_mission_conflicts = 0
+    for entry in conflict_index.values():
+        sorted_workers = sorted(entry["worker_ids"])
+        conflict_records.append(
+            {
+                "field": entry["field"],
+                "value": entry["value"],
+                "worker_ids": sorted_workers,
+                "is_cross_mission": any(worker_id not in worker_ids for worker_id in sorted_workers),
+            }
+        )
+        if conflict_records[-1]["is_cross_mission"]:
+            cross_mission_conflicts += 1
+
+    merge_badges = [
+        {"key": state, "label": MERGE_LABELS[state], "count": count}
+        for state, count in merge_counts.items()
+        if count
+    ]
+    merge_summary = _build_merge_summary(merge_counts)
+    fanout_strip = _build_fanout_strip(worker_dicts)
+    timeline = _build_mission_timeline(worker_ids, worker_details, commands)
+    exception_badges = _build_exception_badges(
+        blocked_workers=blocked_workers,
+        stale_workers=stale_workers,
+        quiet_workers=quiet_workers,
+        ready_workers=ready_workers,
+        cross_mission_conflicts=cross_mission_conflicts,
+        merge_counts=merge_counts,
+    )
+    status_label, attention_rank = _derive_mission_status(
+        blocked_workers=blocked_workers,
+        stale_workers=stale_workers,
+        ready_workers=ready_workers,
+        active_workers=active_workers,
+        worker_count=len(worker_dicts),
+        merge_counts=merge_counts,
+    )
+
+    mission_id = _mission_id(
+        seed_repo,
+        branch_hint=branch_hint,
+        owner_hint=owner_hint or (focus_worker["worker_id"] if focus_worker else None),
+    )
+    repo_name = Path(seed_repo).name or seed_repo
+    goal = _clip_text(goal_hint or _guess_goal(worker_dicts), 88)
+
+    return {
+        "id": mission_id,
+        "owner": owner_hint or (focus_worker["worker_id"] if focus_worker else "unassigned"),
+        "goal": goal or "Awaiting clearer mission objective",
+        "repo_path": seed_repo,
+        "repo_name": repo_name,
+        "branch_hint": branch_hint,
+        "commands": commands,
+        "workers": worker_dicts,
+        "worker_count": len(worker_dicts),
+        "active_workers": active_workers,
+        "blocked_workers": blocked_workers,
+        "stale_workers": stale_workers,
+        "ready_workers": ready_workers,
+        "latest_event_at": latest_event_at,
+        "latest_event_label": worker_freshness(latest_event_at)["label"],
+        "merge_summary": merge_summary,
+        "merge_badges": merge_badges,
+        "conflicts": sorted(conflict_records, key=lambda item: (item["field"], item["value"])),
+        "conflict_count": len(conflict_records),
+        "cross_mission_conflicts": cross_mission_conflicts,
+        "exception_badges": exception_badges,
+        "fanout_strip": fanout_strip,
+        "timeline": timeline[:8],
+        "focus_worker_id": focus_worker["worker_id"] if focus_worker else None,
+        "status_label": status_label,
+        "attention_rank": attention_rank,
+        "selected": False,
+        "worker_search_blob": " ".join(
+            filter(
+                None,
+                [
+                    mission_id,
+                    seed_repo,
+                    branch_hint,
+                    owner_hint,
+                    goal,
+                    " ".join(_worker_search_blob(worker) for worker in worker_dicts),
+                    " ".join(command.operator_instruction for command in commands),
+                ],
+            )
+        ).lower(),
+        "is_solo": len(worker_dicts) == 1,
+        "merge_counts": merge_counts,
+    }
+
+
+def _build_attention_queue(missions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    severity = {
+        "blocked": 0,
+        "conflict": 1,
+        "merge": 2,
+        "review": 3,
+        "stale": 4,
+    }
+    for mission in missions:
+        age_label = mission["latest_event_label"]
+        if mission["blocked_workers"]:
+            items.append(
+                {
+                    "kind": "blocked",
+                    "label": "Blocked",
+                    "reason": f"{mission['blocked_workers']} worker blocked in {mission['repo_name']}",
+                    "age": age_label,
+                    "mission_id": mission["id"],
+                    "severity": severity["blocked"],
+                }
+            )
+        if mission["cross_mission_conflicts"]:
+            items.append(
+                {
+                    "kind": "conflict",
+                    "label": "Conflict",
+                    "reason": f"{mission['cross_mission_conflicts']} cross-mission ownership collision",
+                    "age": age_label,
+                    "mission_id": mission["id"],
+                    "severity": severity["conflict"],
+                }
+            )
+        if mission["merge_counts"]["approved"] or mission["merge_counts"]["merged_to_main"]:
+            items.append(
+                {
+                    "kind": "merge",
+                    "label": "Merge",
+                    "reason": mission["merge_summary"],
+                    "age": age_label,
+                    "mission_id": mission["id"],
+                    "severity": severity["merge"],
+                }
+            )
+        elif mission["ready_workers"]:
+            items.append(
+                {
+                    "kind": "review",
+                    "label": "Review",
+                    "reason": f"{mission['ready_workers']} worker ready for captain handoff",
+                    "age": age_label,
+                    "mission_id": mission["id"],
+                    "severity": severity["review"],
+                }
+            )
+        if mission["stale_workers"]:
+            items.append(
+                {
+                    "kind": "stale",
+                    "label": "Stale",
+                    "reason": f"{mission['stale_workers']} worker stale or quiet",
+                    "age": age_label,
+                    "mission_id": mission["id"],
+                    "severity": severity["stale"],
+                }
+            )
+    return sorted(items, key=lambda item: (item["severity"], item["age"], item["mission_id"]))
+
+
+def _build_summary(missions: list[dict[str, Any]], attention_items: list[dict[str, Any]]) -> dict[str, int]:
+    return {
+        "missions": len(missions),
+        "workers": sum(mission["worker_count"] for mission in missions),
+        "attention": len(attention_items),
+        "blocked": sum(mission["blocked_workers"] for mission in missions),
+        "merge_ready": sum(mission["merge_counts"]["approved"] for mission in missions),
+        "done": sum(1 for mission in missions if mission["status_label"] == "done"),
+    }
+
+
+def _build_mission_board(missions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    buckets = {
+        "needs attention": [],
+        "converging": [],
+        "waiting on review": [],
+        "done": [],
+    }
+    for mission in missions:
+        label = mission["status_label"]
+        if label in {"stuck", "stale"}:
+            buckets["needs attention"].append(mission)
+        elif label == "waiting on review":
+            buckets["waiting on review"].append(mission)
+        elif label == "done":
+            buckets["done"].append(mission)
+        else:
+            buckets["converging"].append(mission)
+    return [{"label": label, "missions": bucket} for label, bucket in buckets.items()]
+
+
+def _build_fanout_clusters(missions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    clusters = []
+    for mission in missions:
+        phase_counts = defaultdict(int)
+        for worker in mission["workers"]:
+            phase_counts[worker["phase_label"]] += 1
         clusters.append(
             {
-                "phase": phase,
-                "label": PHASE_THEATER_LABELS[phase],
-                "count": len(workers),
-                "units": units[:3],
-                "overflow": max(0, len(units) - 3),
+                "mission_id": mission["id"],
+                "owner": mission["owner"],
+                "repo_name": mission["repo_name"],
+                "goal": mission["goal"],
+                "status_label": mission["status_label"],
+                "phase_counts": [
+                    {"label": label, "count": count}
+                    for label, count in sorted(phase_counts.items(), key=lambda item: item[0])
+                ],
+                "worker_count": mission["worker_count"],
             }
         )
     return clusters
+
+
+def _build_dispatch_rows(
+    recent_commands: list[OperatorCommandRecord],
+    missions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    mission_lookup = {mission["repo_path"]: mission for mission in missions}
+    rows = []
+    for command in recent_commands:
+        mission = mission_lookup.get(command.repo_path)
+        rows.append(
+            {
+                "objective": _clip_text(command.operator_instruction, 120),
+                "owner": command.general_worker_id,
+                "repo_path": command.repo_path,
+                "repo_name": Path(command.repo_path).name,
+                "branch_hint": command.branch_hint,
+                "prompt_path": command.prompt_path,
+                "log_path": command.log_path,
+                "launch_time": command.created_at,
+                "progress": mission["status_label"] if mission else "launched",
+                "mission_id": mission["id"] if mission else None,
+                "pid": command.pid,
+            }
+        )
+    return rows
+
+
+def _build_conflict_groups(missions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "mission_id": mission["id"],
+            "repo_name": mission["repo_name"],
+            "goal": mission["goal"],
+            "conflicts": mission["conflicts"],
+        }
+        for mission in missions
+        if mission["conflicts"]
+    ]
+
+
+def _build_worker_rows(missions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows = []
+    for mission in missions:
+        for worker in mission["workers"]:
+            rows.append(
+                {
+                    **worker,
+                    "mission_id": mission["id"],
+                    "mission_goal": mission["goal"],
+                    "mission_owner": mission["owner"],
+                    "repo_name": mission["repo_name"],
+                }
+            )
+    return sorted(
+        rows,
+        key=lambda row: (
+            PHASE_PRIORITY[row["phase"]],
+            row["freshness_state"] != "stale",
+            -row["updated_at"].timestamp(),
+            row["worker_id"],
+        ),
+    )
+
+
+def _apply_search(missions: list[dict[str, Any]], search_query: str) -> list[dict[str, Any]]:
+    if not search_query:
+        return missions
+    return [mission for mission in missions if search_query in mission["worker_search_blob"]]
+
+
+def _apply_saved_view(missions: list[dict[str, Any]], saved_view: str) -> list[dict[str, Any]]:
+    if saved_view == "all-active":
+        return [mission for mission in missions if mission["active_workers"]]
+    if saved_view == "merge-work":
+        return [
+            mission
+            for mission in missions
+            if any(
+                mission["merge_counts"][state]
+                for state in ("pr_open", "changes_requested", "approved", "merged_to_main")
+            )
+        ]
+    if saved_view == "stale-only":
+        return [mission for mission in missions if mission["stale_workers"]]
+    if saved_view == "solo-workers":
+        return [mission for mission in missions if mission["is_solo"]]
+    if saved_view == "needs-attention":
+        return [
+            mission
+            for mission in missions
+            if mission["blocked_workers"]
+            or mission["stale_workers"]
+            or mission["conflict_count"]
+            or mission["ready_workers"]
+            or mission["merge_counts"]["approved"]
+        ]
+    return missions
+
+
+def _pick_selected_worker_id(missions: list[dict[str, Any]], requested_worker_id: str | None) -> str | None:
+    for mission in missions:
+        worker_ids = {worker["worker_id"] for worker in mission["workers"]}
+        if requested_worker_id in worker_ids:
+            return requested_worker_id
+    if missions:
+        return missions[0]["focus_worker_id"]
+    return None
+
+
+def _pick_selected_mission_id(
+    missions: list[dict[str, Any]],
+    *,
+    requested_mission_id: str | None,
+    requested_worker_id: str | None,
+) -> str | None:
+    mission_ids = {mission["id"] for mission in missions}
+    if requested_mission_id in mission_ids:
+        return requested_mission_id
+    if requested_worker_id:
+        for mission in missions:
+            if any(worker["worker_id"] == requested_worker_id for worker in mission["workers"]):
+                return mission["id"]
+    if missions:
+        return missions[0]["id"]
+    return None
+
+
+def _build_mission_timeline(
+    worker_ids: list[str],
+    worker_details: dict[str, WorkerDetail],
+    commands: list[OperatorCommandRecord],
+) -> list[dict[str, Any]]:
+    events = []
+    for command in commands:
+        events.append(
+            {
+                "type": "dispatch",
+                "label": "Dispatched",
+                "summary": _clip_text(command.operator_instruction, 96),
+                "timestamp": command.created_at,
+                "worker_id": None,
+            }
+        )
+    for worker_id in worker_ids:
+        detail = worker_details[worker_id]
+        for transition in detail.transitions:
+            events.append(
+                {
+                    "type": _timeline_type(transition.current_phase, transition.pr_url, transition.status_line, transition.note),
+                    "label": _timeline_label(transition.current_phase, transition.pr_url, transition.status_line, transition.note),
+                    "summary": _clip_text(transition.note or transition.status_line, 96),
+                    "timestamp": transition.created_at,
+                    "worker_id": worker_id,
+                }
+            )
+    return sorted(events, key=lambda event: event["timestamp"], reverse=True)
+
+
+def _timeline_type(
+    phase: WorkerPhase,
+    pr_url: str | None,
+    status_line: str,
+    note: str | None,
+) -> str:
+    text = f"{status_line} {note or ''}".lower()
+    if "merged" in text:
+        return "merged"
+    if pr_url:
+        return "pr"
+    if phase == WorkerPhase.BLOCKED:
+        return "blocked"
+    if phase == WorkerPhase.HANDOFF_READY:
+        return "review"
+    if phase == WorkerPhase.TERMINAL:
+        return "terminal"
+    return "state"
+
+
+def _timeline_label(
+    phase: WorkerPhase,
+    pr_url: str | None,
+    status_line: str,
+    note: str | None,
+) -> str:
+    kind = _timeline_type(phase, pr_url, status_line, note)
+    if kind == "merged":
+        return "Merged"
+    if kind == "pr":
+        return "PR Opened"
+    if kind == "blocked":
+        return "Blocked"
+    if kind == "review":
+        return "Review Requested"
+    if kind == "terminal":
+        return "Terminal"
+    return f"State: {phase.value}"
+
+
+def _index_conflicts(conflicts: list[ConflictRecord]) -> dict[str, list[ConflictRecord]]:
+    indexed: dict[str, list[ConflictRecord]] = defaultdict(list)
+    for conflict in conflicts:
+        for worker_id in conflict.worker_ids:
+            indexed[worker_id].append(conflict)
+    return indexed
+
+
+def _build_fanout_strip(workers: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_phase: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for worker in workers:
+        by_phase[worker["phase_label"]].append(worker)
+    strip = []
+    for phase in sorted(by_phase.keys()):
+        phase_workers = by_phase[phase]
+        strip.append(
+            {
+                "label": phase,
+                "count": len(phase_workers),
+                "workers": phase_workers[:4],
+                "overflow": max(0, len(phase_workers) - 4),
+            }
+        )
+    return strip
+
+
+def _build_exception_badges(
+    *,
+    blocked_workers: int,
+    stale_workers: int,
+    quiet_workers: int,
+    ready_workers: int,
+    cross_mission_conflicts: int,
+    merge_counts: dict[str, int],
+) -> list[dict[str, Any]]:
+    badges = []
+    if blocked_workers:
+        badges.append({"tone": "blocked", "label": f"{blocked_workers} blocked"})
+    if cross_mission_conflicts:
+        badges.append({"tone": "conflict", "label": f"{cross_mission_conflicts} conflicts"})
+    if stale_workers:
+        badges.append({"tone": "stale", "label": f"{stale_workers} stale"})
+    elif quiet_workers:
+        badges.append({"tone": "quiet", "label": f"{quiet_workers} quiet"})
+    if ready_workers:
+        badges.append({"tone": "review", "label": f"{ready_workers} handoff ready"})
+    if merge_counts["approved"]:
+        badges.append({"tone": "merge", "label": f"{merge_counts['approved']} approved"})
+    return badges
+
+
+def _derive_mission_status(
+    *,
+    blocked_workers: int,
+    stale_workers: int,
+    ready_workers: int,
+    active_workers: int,
+    worker_count: int,
+    merge_counts: dict[str, int],
+) -> tuple[str, int]:
+    if blocked_workers:
+        return "stuck", 0
+    if stale_workers:
+        return "stale", 1
+    if merge_counts["approved"] or merge_counts["changes_requested"] or ready_workers:
+        return "waiting on review", 2
+    if worker_count and active_workers == 0:
+        return "done", 4
+    return "converging", 3
+
+
+def _infer_merge_state(worker: WorkerDetail) -> str:
+    text = " ".join(
+        filter(
+            None,
+            [
+                worker.status_line,
+                worker.blocker,
+                worker.last_note.note if worker.last_note else None,
+                " ".join(note.note for note in worker.notes[:6]),
+            ],
+        )
+    ).lower()
+    if "synced locally" in text or "synced local" in text:
+        return "synced_locally"
+    if "merged to main" in text or "merged on main" in text or "merged" in text:
+        return "merged_to_main"
+    if "changes requested" in text or "requested changes" in text:
+        return "changes_requested"
+    if "approved" in text:
+        return "approved"
+    if worker.pr_url:
+        return "approved" if worker.phase == WorkerPhase.HANDOFF_READY else "pr_open"
+    if worker.branch:
+        return "branch_active"
+    return "no_branch"
+
+
+def _build_merge_summary(merge_counts: dict[str, int]) -> str:
+    parts = []
+    for state in ("pr_open", "changes_requested", "approved", "merged_to_main", "synced_locally"):
+        count = merge_counts[state]
+        if count:
+            parts.append(f"{count} {MERGE_LABELS[state]}")
+    if parts:
+        return ", ".join(parts)
+    if merge_counts["branch_active"]:
+        return f"{merge_counts['branch_active']} branch active"
+    return "no branch activity"
+
+
+def _pick_focus_worker_dict(workers: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not workers:
+        return None
+    return sorted(
+        workers,
+        key=lambda worker: (
+            PHASE_PRIORITY[worker["phase"]],
+            worker["freshness_state"] != "stale",
+            -worker["updated_at"].timestamp(),
+            worker["worker_id"],
+        ),
+    )[0]
+
+
+def _guess_goal(workers: list[dict[str, Any]]) -> str:
+    focus = _pick_focus_worker_dict(workers)
+    if not focus:
+        return ""
+    return focus["next_irreversible_step"] or focus["status_line"]
+
+
+def _worker_search_blob(worker: dict[str, Any]) -> str:
+    return " ".join(
+        filter(
+            None,
+            [
+                worker["worker_id"],
+                worker["repo_path"],
+                worker["branch"],
+                worker["owned_artifact"],
+                worker["blocker"],
+                worker["pr_url"],
+                worker["status_line"],
+                worker["next_irreversible_step"],
+            ],
+        )
+    )
+
+
+def _mission_id(repo_path: str, *, branch_hint: str | None, owner_hint: str | None) -> str:
+    repo_name = Path(repo_path).name or "repo"
+    branch = (branch_hint or owner_hint or "mission").replace("/", "-")
+    return f"{repo_name}:{branch}".lower()
+
+
+def _clip_text(value: str | None, limit: int) -> str:
+    if not value:
+        return ""
+    compact = " ".join(value.split())
+    if len(compact) <= limit:
+        return compact
+    return f"{compact[: limit - 1].rstrip()}..."
+
+
+def _titleize(value: str) -> str:
+    return value.replace("-", " ").title()
+
+
+def _age_seconds(value: datetime) -> int:
+    now = datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return max(0, int((now - value.astimezone(timezone.utc)).total_seconds()))

--- a/overlord/static/styles.css
+++ b/overlord/static/styles.css
@@ -1,19 +1,22 @@
 :root {
-  --bg: #08111f;
-  --bg-deep: #040812;
-  --panel: rgba(10, 19, 35, 0.8);
-  --panel-strong: rgba(11, 25, 45, 0.92);
-  --panel-soft: rgba(18, 33, 58, 0.72);
-  --line: rgba(115, 178, 255, 0.16);
-  --line-strong: rgba(115, 178, 255, 0.3);
-  --text: #eef5ff;
-  --muted: #8ea4c6;
-  --accent: #65d8ff;
-  --accent-strong: #8ff7d9;
-  --alert: #ff7d6b;
-  --warn: #ffca69;
-  --success: #97f59f;
-  --shadow: 0 28px 80px rgba(0, 0, 0, 0.42);
+  --bg: #eef2f6;
+  --panel: #fbfcfd;
+  --panel-strong: #ffffff;
+  --panel-muted: #f4f7fa;
+  --line: #c9d3de;
+  --line-strong: #97a7b8;
+  --text: #102133;
+  --muted: #5d7286;
+  --blue: #0c63a8;
+  --blue-soft: #d9ebf8;
+  --red: #b23b31;
+  --red-soft: #f9dfdb;
+  --amber: #9a6408;
+  --amber-soft: #f8edd2;
+  --green: #197246;
+  --green-soft: #dbeedd;
+  --slate-soft: #e5ebf2;
+  --shadow: 0 18px 34px rgba(16, 33, 51, 0.08);
 }
 
 * {
@@ -27,675 +30,613 @@ html {
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  font-family: "Manrope", "Segoe UI", sans-serif;
   color: var(--text);
   background:
-    radial-gradient(circle at top, rgba(101, 216, 255, 0.12), transparent 28%),
-    radial-gradient(circle at 20% 20%, rgba(143, 247, 217, 0.12), transparent 16%),
-    radial-gradient(circle at 80% 30%, rgba(255, 125, 107, 0.08), transparent 18%),
-    linear-gradient(180deg, #0b1424 0%, var(--bg) 42%, var(--bg-deep) 100%);
-}
-
-body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  background-image:
-    linear-gradient(rgba(143, 247, 217, 0.03) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(143, 247, 217, 0.03) 1px, transparent 1px);
-  background-size: 44px 44px;
-  mask-image: radial-gradient(circle at center, black 38%, transparent 90%);
+    linear-gradient(180deg, rgba(12, 99, 168, 0.06), transparent 26%),
+    linear-gradient(135deg, rgba(248, 237, 210, 0.55), transparent 38%),
+    var(--bg);
 }
 
 a {
-  color: var(--accent);
+  color: inherit;
   text-decoration: none;
 }
 
 a:hover {
-  text-decoration: underline;
+  text-decoration: none;
 }
 
-code {
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.92em;
+code,
+.mono-line {
+  font-family: "IBM Plex Mono", "Space Mono", monospace;
 }
 
 h1,
 h2,
 h3,
-h4,
 p {
   margin: 0;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  font-family: "Rajdhani", "Space Grotesk", sans-serif;
-  letter-spacing: 0.03em;
+button,
+input,
+select,
+textarea {
+  font: inherit;
 }
 
-h1 {
-  font-size: clamp(3rem, 9vw, 5.8rem);
-  line-height: 0.9;
+button {
+  cursor: pointer;
 }
 
-h2 {
-  font-size: clamp(1.8rem, 3vw, 2.5rem);
-}
-
-h3 {
-  font-size: 1.2rem;
-}
-
-h4 {
-  font-size: 1rem;
-}
-
-.shell {
-  width: min(1520px, calc(100% - 1.5rem));
+.app-shell {
+  width: min(1600px, calc(100% - 1rem));
   margin: 0 auto;
-  padding: 1rem 0 2rem;
+  padding: 0.75rem 0 1rem;
 }
 
-.panel {
-  position: relative;
-  overflow: hidden;
+.topbar,
+.rail-panel,
+.canvas-panel,
+.board-card,
+.fanout-card,
+.list-row,
+.conflict-group,
+.mission-row,
+.worker-tile,
+.timeline-entry,
+.phase-note-group,
+.attention-item {
   border: 1px solid var(--line);
-  border-radius: 28px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 24%),
-    var(--panel);
+  border-radius: 16px;
+  background: var(--panel-strong);
   box-shadow: var(--shadow);
-  backdrop-filter: blur(16px);
 }
 
-.panel::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: linear-gradient(135deg, rgba(101, 216, 255, 0.08), transparent 36%);
-}
-
-.hero,
-.hero-grid,
-.hero-copy,
-.focus-summary,
-.summary-grid,
-.main-column,
-.rail,
-.report-form,
-.form-actions,
-.worker-list,
-.chip-row,
-.note,
-.detail-grid,
-.detail-section,
-.timeline,
-.phase-note-groups,
-.phase-note-list,
-.note-feed,
-.conflict-list,
-.unit-list {
+.topbar {
   display: grid;
-  gap: 1rem;
-}
-
-.hero {
-  padding: 1.4rem;
-}
-
-.hero-topline,
-.meta-strip,
-.section-head,
-.phase-header,
-.worker-head,
-.focus-card-head,
-.timeline-head,
-.phase-note-header,
-.relay-header {
-  display: flex;
+  grid-template-columns: minmax(220px, 0.9fr) minmax(200px, 0.7fr) minmax(260px, 1fr);
+  gap: 0.9rem;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.8rem;
+  padding: 1rem 1.1rem;
+  margin-bottom: 0.85rem;
 }
 
-.hero-grid {
-  grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.9fr);
-  align-items: end;
+.brand-block h1 {
+  font-size: clamp(1.7rem, 2vw, 2.2rem);
 }
 
-.eyebrow,
-.pill,
-.note-phase,
-.refresh-pill,
-.freshness-pill,
-.section-tag {
+.workspace-shell {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr) 330px;
+  gap: 0.85rem;
+  align-items: start;
+}
+
+.left-rail,
+.main-canvas,
+.right-rail,
+.rail-nav,
+.saved-view-list,
+.metrics-panel,
+.attention-list,
+.compact-form,
+.worker-grid-list,
+.timeline-list,
+.phase-note-groups,
+.board-grid,
+.fanout-map,
+.list-table,
+.settings-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.rail-nav .rail-link,
+.saved-view,
+.switch-link,
+.dispatch-cta {
+  transition: background-color 140ms ease, border-color 140ms ease, color 140ms ease, transform 140ms ease;
+}
+
+.rail-link,
+.saved-view,
+.switch-link,
+.dispatch-cta {
   display: inline-flex;
   align-items: center;
-  width: fit-content;
-  padding: 0.34rem 0.8rem;
+  justify-content: center;
+  min-height: 2.3rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--line);
   border-radius: 999px;
-  border: 1px solid rgba(101, 216, 255, 0.22);
-  background: rgba(101, 216, 255, 0.08);
-  color: var(--accent);
-  font-size: 0.77rem;
+  background: var(--panel-strong);
+}
+
+.rail-link-accent,
+.saved-view-selected,
+.switch-link-selected,
+.dispatch-cta {
+  border-color: rgba(12, 99, 168, 0.28);
+  background: var(--blue-soft);
+  color: var(--blue);
+}
+
+.dispatch-cta {
+  font-weight: 700;
+}
+
+.topbar-meta,
+.view-switcher,
+.canvas-meta,
+.mission-stats,
+.badge-row,
+.fanout-workers,
+.timeline-top,
+.worker-tile-head,
+.board-head,
+.list-meta,
+.split-fields,
+.dossier-meta {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.search-form {
+  grid-column: 3;
+}
+
+.search-box,
+.compact-form label {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.search-box input,
+.compact-form input,
+.compact-form select,
+.compact-form textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel-muted);
+  color: var(--text);
+  padding: 0.62rem 0.72rem;
+}
+
+.compact-form button {
+  border: 1px solid rgba(12, 99, 168, 0.28);
+  border-radius: 10px;
+  background: var(--blue);
+  color: #fff;
+  padding: 0.72rem 0.9rem;
+  font-weight: 700;
+}
+
+.label,
+.eyebrow,
+.subtle {
+  color: var(--muted);
+}
+
+.label,
+.eyebrow {
+  font-size: 0.76rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.refresh-pill,
+.subtle {
+  font-size: 0.9rem;
+}
+
+.meta-pill,
+.meta-chip,
+.badge,
+.owner-pill,
 .section-tag {
-  color: var(--accent-strong);
-  border-style: dashed;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
 }
 
-.lede,
-.muted-text,
-.section-head p,
-.relay-copy,
-.status-line,
-.next-step,
-.focus-line,
-.repo-line,
-.timeline-note,
-.empty-state,
-.core-line,
-.meta-strip {
-  color: var(--muted);
-}
-
-.focus-summary,
-.summary-card,
-.command-core,
-.relay-card,
-.relay-empty,
-.phase-column,
-.worker-card,
-.focus-card,
-.timeline-card,
-.phase-note-group,
-.phase-note-card,
-.feed-card,
-.conflict-card {
-  position: relative;
-  z-index: 1;
+.meta-pill,
+.meta-chip,
+.section-tag {
+  padding: 0.34rem 0.62rem;
+  background: var(--panel-muted);
   border: 1px solid var(--line);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), var(--panel-soft));
 }
 
-.focus-summary,
-.summary-card {
-  border-radius: 22px;
-  padding: 1rem;
+.badge,
+.owner-pill {
+  padding: 0.28rem 0.56rem;
 }
 
-.focus-summary {
-  align-self: stretch;
+.badge-status,
+.owner-pill {
+  background: var(--slate-soft);
+  color: var(--text);
 }
 
-.summary-grid {
-  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+.badge-blocked,
+.badge-conflict,
+.badge-stale,
+.banner-error {
+  background: var(--red-soft);
+  color: var(--red);
 }
 
-.summary-card-alert {
-  border-color: rgba(255, 125, 107, 0.28);
-  background: linear-gradient(180deg, rgba(255, 125, 107, 0.08), rgba(34, 13, 20, 0.7));
+.badge-review,
+.badge-merge,
+.badge-active,
+.banner-success {
+  background: var(--green-soft);
+  color: var(--green);
 }
 
-.label {
-  display: block;
-  margin-bottom: 0.45rem;
+.badge-quiet {
+  background: var(--slate-soft);
   color: var(--muted);
-  font-size: 0.74rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
 }
 
-.metric {
-  font-size: 2.35rem;
-  font-weight: 700;
+.badge-merge {
+  background: var(--blue-soft);
+  color: var(--blue);
 }
 
-.focus-worker {
-  font-size: 1.35rem;
-  font-weight: 700;
+.left-rail,
+.main-canvas,
+.right-rail {
+  min-width: 0;
 }
 
-.meta-strip {
-  flex-wrap: wrap;
-  font-size: 0.92rem;
+.rail-panel,
+.canvas-panel {
+  padding: 0.9rem;
 }
 
-.layout-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.55fr) minmax(320px, 0.9fr);
-  gap: 1rem;
-  margin-top: 1rem;
+.canvas-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.9rem;
+  align-items: start;
+  margin-bottom: 0.75rem;
 }
 
-.main-column,
-.rail {
-  align-content: start;
-}
-
-.panel {
-  padding: 1.2rem;
+.canvas-copy {
+  margin-top: 0.35rem;
+  color: var(--muted);
 }
 
 .section-head {
-  align-items: flex-start;
-  margin-bottom: 1rem;
-}
-
-.section-head-tight {
-  margin-bottom: 0;
-}
-
-.network-stage {
-  min-height: 560px;
-}
-
-.network-map {
-  position: relative;
-  display: grid;
-  grid-template-columns: minmax(280px, 0.95fr) minmax(0, 1.45fr);
-  gap: 1rem;
-  min-height: 460px;
-}
-
-.network-map-empty {
-  grid-template-columns: 1fr;
-}
-
-.network-rings {
-  position: absolute;
-  inset: 1rem;
-  pointer-events: none;
-  background:
-    radial-gradient(circle at center, rgba(101, 216, 255, 0.18) 0 2px, transparent 2px),
-    radial-gradient(circle at center, transparent 0 17%, rgba(101, 216, 255, 0.08) 17.5%, transparent 18%),
-    radial-gradient(circle at center, transparent 0 31%, rgba(101, 216, 255, 0.08) 31.5%, transparent 32%),
-    radial-gradient(circle at center, transparent 0 46%, rgba(101, 216, 255, 0.08) 46.5%, transparent 47%),
-    radial-gradient(circle at center, rgba(143, 247, 217, 0.18), transparent 62%);
-  opacity: 0.85;
-}
-
-.command-core,
-.relay-card,
-.relay-empty {
-  border-radius: 24px;
-  padding: 1rem;
-}
-
-.command-core {
-  align-self: center;
-  justify-self: center;
-  width: min(100%, 360px);
-  background:
-    radial-gradient(circle at top, rgba(101, 216, 255, 0.16), transparent 52%),
-    linear-gradient(180deg, rgba(13, 41, 69, 0.95), rgba(7, 17, 31, 0.96));
-  box-shadow:
-    inset 0 0 0 1px rgba(101, 216, 255, 0.12),
-    0 0 50px rgba(101, 216, 255, 0.1);
-}
-
-.command-core h3 {
-  font-size: 2rem;
-}
-
-.core-grid,
-.focus-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.9rem;
-  margin-top: 1rem;
-}
-
-.relay-grid {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-  align-content: center;
-}
-
-.relay-card {
-  min-height: 180px;
-}
-
-.relay-card::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: -1rem;
-  width: 1rem;
-  border-top: 1px solid rgba(101, 216, 255, 0.18);
-}
-
-.relay-card:nth-child(2n)::after {
-  left: auto;
-  right: -1rem;
-}
-
-.unit-list {
-  margin-top: 0.8rem;
-}
-
-.unit-node {
-  display: grid;
-  gap: 0.15rem;
-  padding: 0.75rem 0.8rem;
-  border: 1px solid rgba(101, 216, 255, 0.14);
-  border-radius: 18px;
-  background: rgba(4, 10, 20, 0.58);
-  color: var(--text);
-  transition: transform 140ms ease, border-color 140ms ease, background 140ms ease;
-}
-
-.unit-node:hover {
-  text-decoration: none;
-  transform: translateY(-1px);
-  border-color: rgba(101, 216, 255, 0.32);
-  background: rgba(8, 18, 34, 0.8);
-}
-
-.unit-node-selected {
-  border-color: rgba(143, 247, 217, 0.44);
-  box-shadow: inset 0 0 0 1px rgba(143, 247, 217, 0.18);
-}
-
-.unit-name {
-  font-weight: 700;
-}
-
-.unit-phase,
-.timestamp {
-  color: var(--muted);
-  font-size: 0.82rem;
-}
-
-.phase-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.phase-column,
-.worker-card,
-.focus-card,
-.timeline-card,
-.phase-note-group,
-.phase-note-card,
-.feed-card,
-.conflict-card {
-  border-radius: 22px;
-}
-
-.phase-column {
-  padding: 1rem;
-}
-
-.worker-card,
-.focus-card,
-.timeline-card,
-.phase-note-group,
-.phase-note-card,
-.feed-card,
-.conflict-card {
-  padding: 0.95rem;
-}
-
-.worker-card {
-  gap: 0.8rem;
-}
-
-.worker-card-selected {
-  border-color: rgba(143, 247, 217, 0.4);
-  box-shadow: inset 0 0 0 1px rgba(143, 247, 217, 0.12);
-}
-
-.worker-link {
-  font-weight: 700;
-  color: inherit;
-}
-
-.chip-row {
-  grid-auto-flow: column;
-  grid-auto-columns: max-content;
-  overflow-x: auto;
-  padding-bottom: 0.2rem;
-}
-
-.meta-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.38rem;
-  padding: 0.28rem 0.56rem;
-  border-radius: 999px;
-  border: 1px solid rgba(101, 216, 255, 0.14);
-  background: rgba(101, 216, 255, 0.08);
-  font-size: 0.78rem;
-}
-
-.repo-line strong,
-.next-step strong,
-.blocker strong {
-  color: var(--text);
-}
-
-.detail-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin-top: 1rem;
-}
-
-.form-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.9rem;
-}
-
-.report-form label {
-  display: grid;
-  gap: 0.45rem;
-}
-
-.form-span-2 {
-  grid-column: 1 / -1;
-}
-
-input,
-select,
-textarea,
-button {
-  font: inherit;
-}
-
-input,
-select,
-textarea {
-  width: 100%;
-  padding: 0.82rem 0.92rem;
-  border: 1px solid var(--line-strong);
-  border-radius: 16px;
-  background: rgba(6, 14, 27, 0.82);
-  color: var(--text);
-}
-
-textarea {
-  resize: vertical;
-}
-
-input:focus,
-select:focus,
-textarea:focus {
-  outline: 2px solid rgba(101, 216, 255, 0.18);
-  border-color: rgba(101, 216, 255, 0.44);
-}
-
-button {
-  width: fit-content;
-  padding: 0.84rem 1.2rem;
-  border: 0;
-  border-radius: 999px;
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  color: #04111d;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-button:hover {
-  filter: brightness(1.05);
-}
-
-.banner {
-  margin-bottom: 1rem;
-  padding: 0.85rem 0.95rem;
-  border-radius: 16px;
-  border: 1px solid transparent;
-}
-
-.banner-success {
-  background: rgba(151, 245, 159, 0.1);
-  border-color: rgba(151, 245, 159, 0.24);
-  color: var(--success);
-}
-
-.banner-error {
-  background: rgba(255, 125, 107, 0.1);
-  border-color: rgba(255, 125, 107, 0.24);
-  color: var(--alert);
-}
-
-.timeline-title {
   display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: start;
+  margin-bottom: 0.75rem;
+}
+
+.section-head p {
+  margin-top: 0.25rem;
+  color: var(--muted);
+}
+
+.metric-block {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--panel-muted);
+}
+
+.metric-block strong {
+  font-size: 1.35rem;
+}
+
+.mission-table {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.mission-row summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 0.9rem;
+}
+
+.mission-row summary::-webkit-details-marker {
+  display: none;
+}
+
+.mission-row-selected {
+  border-color: rgba(12, 99, 168, 0.36);
+}
+
+.mission-summary {
+  display: grid;
+  grid-template-columns: minmax(260px, 2fr) repeat(3, minmax(120px, auto));
+  gap: 0.85rem;
+  align-items: start;
+}
+
+.mission-title-row {
+  display: flex;
+  gap: 0.55rem;
   align-items: center;
-  gap: 0.45rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.35rem;
+}
+
+.mission-primary h3 {
+  font-size: 1.05rem;
+}
+
+.mission-summary-lower {
+  display: grid;
+  gap: 0.7rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--line);
+}
+
+.fanout-strip {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.fanout-group {
+  display: flex;
+  gap: 0.55rem;
+  align-items: center;
   flex-wrap: wrap;
 }
 
-.timeline-arrow {
+.fanout-label {
+  min-width: 120px;
+  font-size: 0.8rem;
+  font-weight: 700;
   color: var(--muted);
 }
 
-.phase-note-card p:last-child,
-.timeline-card p:last-child,
-.feed-card p:last-child {
-  margin-top: 0.35rem;
+.worker-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.26rem 0.52rem;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--panel-muted);
+  font-size: 0.8rem;
 }
 
-.freshness-pill-fresh,
-.freshness-fresh {
-  border-color: rgba(151, 245, 159, 0.24);
+.worker-chip-active {
+  border-color: rgba(12, 99, 168, 0.2);
+  background: var(--blue-soft);
 }
 
-.freshness-pill-fresh {
-  background: rgba(151, 245, 159, 0.1);
-  color: var(--success);
+.worker-chip-quiet,
+.worker-chip-overflow {
+  color: var(--muted);
 }
 
-.freshness-pill-aging,
-.freshness-aging,
-.phase-blocked {
-  border-color: rgba(255, 202, 105, 0.28);
+.worker-chip-stale {
+  border-color: rgba(178, 59, 49, 0.24);
+  background: var(--red-soft);
 }
 
-.freshness-pill-aging {
-  background: rgba(255, 202, 105, 0.1);
-  color: var(--warn);
+.mission-detail,
+.worker-grid,
+.dossier-grid {
+  display: grid;
+  gap: 0.75rem;
 }
 
-.freshness-pill-stale,
-.freshness-stale,
-.phase-handoff-ready {
-  border-color: rgba(255, 125, 107, 0.28);
+.mission-detail {
+  padding: 0 0.9rem 0.9rem;
 }
 
-.freshness-pill-stale {
-  background: rgba(255, 125, 107, 0.1);
-  color: var(--alert);
+.worker-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.phase-implementing,
-.phase-validating {
-  border-color: rgba(101, 216, 255, 0.24);
+.dossier-grid {
+  grid-template-columns: 1.2fr 1fr 0.9fr;
 }
 
-.phase-assigned,
-.phase-scouting,
-.phase-planned,
-.phase-terminal {
-  border-color: rgba(143, 247, 217, 0.18);
+.detail-card {
+  padding: 0.85rem;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--panel-muted);
 }
 
-.blocker {
-  color: var(--alert);
+.worker-grid-list {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.empty-state {
-  padding-top: 0.4rem;
+.worker-tile {
+  padding: 0.8rem;
+}
+
+.worker-tile-selected,
+.worker-tile:hover,
+.attention-item:hover,
+.list-row:hover,
+.board-card:hover {
+  border-color: rgba(12, 99, 168, 0.32);
+  transform: translateY(-1px);
+}
+
+.worker-tile p,
+.timeline-entry p,
+.phase-note-group p,
+.attention-item p,
+.board-card p,
+.fanout-card p,
+.list-row p,
+.settings-list p,
+.conflict-item p {
+  margin-top: 0.25rem;
+}
+
+.worker-tile-stale,
+.badge-blocked,
+.blocker-line {
+  color: var(--red);
+}
+
+.worker-tile-quiet {
+  border-style: dashed;
+}
+
+.timeline-list {
+  max-height: 420px;
+  overflow: auto;
+}
+
+.timeline-entry,
+.phase-note-group,
+.attention-item,
+.board-card,
+.fanout-card,
+.conflict-item {
+  padding: 0.7rem;
+}
+
+.attention-item {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.banner-success,
+.banner-error {
+  padding: 0.6rem 0.7rem;
+  border-radius: 12px;
+  font-weight: 600;
+}
+
+.board-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.board-column {
+  display: grid;
+  gap: 0.65rem;
+  align-content: start;
+}
+
+.fanout-map {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.list-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding: 0.8rem;
+}
+
+.conflict-group {
+  padding: 0.8rem;
+}
+
+.settings-list code,
+.repo-line code,
+.mono-line code,
+.meta-chip code {
+  font-size: 0.84em;
 }
 
 @media (max-width: 1180px) {
-  .layout-grid,
-  .hero-grid,
-  .network-map,
-  .detail-grid {
-    grid-template-columns: 1fr;
+  .workspace-shell {
+    grid-template-columns: 220px minmax(0, 1fr);
   }
 
-  .network-stage {
-    min-height: unset;
+  .right-rail {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.85rem;
   }
 
-  .relay-grid {
-    grid-template-columns: 1fr;
+  .dossier-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .relay-card::after {
-    display: none;
+  .dossier-card {
+    grid-column: 1 / -1;
   }
 }
 
-@media (max-width: 860px) {
-  .shell {
-    width: min(100% - 1rem, 1520px);
-    padding-top: 0.5rem;
-  }
-
-  .panel {
-    padding: 1rem;
-    border-radius: 24px;
-  }
-
-  .summary-grid,
-  .phase-grid,
-  .core-grid,
-  .focus-grid,
-  .form-grid {
+@media (max-width: 900px) {
+  .topbar {
     grid-template-columns: 1fr;
   }
 
-  .chip-row {
-    grid-auto-flow: row;
-    grid-auto-columns: unset;
-    overflow: visible;
+  .search-form {
+    grid-column: auto;
   }
 
-  .worker-head,
-  .focus-card-head,
-  .timeline-head,
-  .phase-note-header,
-  .section-head,
-  .relay-header {
-    align-items: flex-start;
-    flex-direction: column;
+  .workspace-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .left-rail {
+    order: 2;
+  }
+
+  .right-rail {
+    order: 1;
+    grid-template-columns: 1fr;
+  }
+
+  .main-canvas {
+    order: 0;
+  }
+
+  .mission-summary,
+  .worker-grid,
+  .dossier-grid,
+  .board-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .canvas-head {
+    display: grid;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    width: min(100%, calc(100% - 0.5rem));
+  }
+
+  .left-rail {
+    display: none;
+  }
+
+  .canvas-meta,
+  .mission-stats,
+  .fanout-strip .fanout-group:not(:first-child) {
+    display: none;
+  }
+
+  .mission-summary {
+    gap: 0.45rem;
+  }
+
+  .mission-summary-lower {
+    padding-top: 0.55rem;
+  }
+
+  .worker-grid-list {
+    grid-template-columns: 1fr;
   }
 }

--- a/overlord/templates/index.html
+++ b/overlord/templates/index.html
@@ -3,541 +3,592 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="refresh" content="10">
+    <meta http-equiv="refresh" content="15">
     <title>{{ app_name }}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;700&family=Rajdhani:wght@500;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', path='/styles.css') }}">
   </head>
   <body>
-    <main class="shell">
-      <section class="hero panel">
-        <div class="hero-topline">
-          <span class="eyebrow">Command theater</span>
-          <span class="refresh-pill">refreshes every 10s</span>
+    <main class="app-shell">
+      <header class="topbar">
+        <div class="brand-block">
+          <p class="eyebrow">Mission supervision</p>
+          <h1>{{ app_name }}</h1>
         </div>
-        <div class="hero-grid">
-          <div class="hero-copy">
-            <h1>{{ app_name }}</h1>
-            <p class="lede">
-              Watch local agents move like a live command network instead of a pane of counters.
-            </p>
-            <p class="muted-text">
-              The network map below is inferred from real worker phases, freshness, and dispatch history. It does not invent captain hierarchies that the store does not have.
-            </p>
-          </div>
-          <article class="focus-summary">
-            <span class="label">Current Focus</span>
-            {% if selected_worker %}
-            <p class="focus-worker">{{ selected_worker.worker_id }}</p>
-            <p class="focus-line">{{ selected_worker.status_line }}</p>
-            <div class="chip-row">
-              <span class="meta-chip"><strong>phase</strong> {{ selected_worker.phase.value }}</span>
-              {% if selected_worker.branch %}
-              <span class="meta-chip"><strong>branch</strong> <code>{{ selected_worker.branch }}</code></span>
-              {% endif %}
-            </div>
-            {% else %}
-            <p class="focus-worker">No active units</p>
-            <p class="focus-line">Post a worker transition to light up the map.</p>
-            {% endif %}
-          </article>
+        <div class="topbar-meta">
+          <span class="meta-pill">{{ environment }}</span>
+          <span class="meta-pill">{{ workspace }}</span>
+          <span class="meta-pill">refresh 15s</span>
         </div>
-        <div class="summary-grid">
-          <article class="summary-card">
-            <span class="label">Network Size</span>
-            <p class="metric">{{ snapshot.totals.workers }}</p>
-          </article>
-          <article class="summary-card">
-            <span class="label">Active Links</span>
-            <p class="metric">{{ snapshot.totals.active }}</p>
-          </article>
-          <article class="summary-card summary-card-alert">
-            <span class="label">Hot Sectors</span>
-            <p class="metric">{{ snapshot.totals.blocked }}</p>
-          </article>
-          <article class="summary-card">
-            <span class="label">Ready For Handoff</span>
-            <p class="metric">{{ snapshot.totals.handoff_ready }}</p>
-          </article>
-        </div>
-        <div class="meta-strip">
-          <span><strong>Environment</strong> {{ environment }}</span>
-          <span><strong>Workspace</strong> {{ workspace }}</span>
-          <span><strong>State</strong> <code>{{ data_dir }}/overlord.db</code></span>
-          <span><strong>Allowlist</strong> <code>{{ allowed_repo_roots | join(", ") }}</code></span>
-        </div>
-      </section>
+        <form class="search-form" action="/" method="get">
+          <input type="hidden" name="view" value="{{ supervision.current_view }}">
+          <input type="hidden" name="saved_view" value="{{ supervision.saved_view }}">
+          <label class="search-box">
+            <span class="label">Search</span>
+            <input name="q" value="{{ supervision.search_query }}" placeholder="worker id, repo, branch, blocker, PR">
+          </label>
+        </form>
+        <nav class="view-switcher" aria-label="Primary views">
+          {% for tab in supervision.view_tabs %}
+          <a class="switch-link{% if tab.selected %} switch-link-selected{% endif %}" href="/?view={{ tab.key }}&saved_view={{ supervision.saved_view }}{% if supervision.search_active %}&q={{ supervision.search_query }}{% endif %}">
+            {{ tab.label }}
+          </a>
+          {% endfor %}
+        </nav>
+        <a class="dispatch-cta" href="#dispatch-pane">New Dispatch</a>
+      </header>
 
-      <section class="layout-grid">
-        <section class="main-column">
-          <article class="panel network-stage">
+      <div class="workspace-shell">
+        <aside class="left-rail">
+          <nav class="rail-nav" aria-label="Sections">
+            <a class="rail-link rail-link-accent" href="/?view=missions&saved_view=needs-attention">Needs Attention</a>
+            <a class="rail-link" href="/?view=missions&saved_view=all-active">All Missions</a>
+            <a class="rail-link" href="/?view=dispatches&saved_view={{ supervision.saved_view }}">Dispatches</a>
+            <a class="rail-link" href="/?view=conflicts&saved_view={{ supervision.saved_view }}">Conflicts</a>
+            <a class="rail-link" href="/?view=workers&saved_view={{ supervision.saved_view }}">Workers</a>
+            <a class="rail-link" href="#settings-panel">Settings</a>
+          </nav>
+
+          <section class="rail-panel">
             <div class="section-head">
               <div>
-                <h2>Battle Network</h2>
-                <p>Central command core with phase relays and live worker nodes.</p>
+                <h2>Saved Views</h2>
+                <p>Fast filters for the daily manager loop.</p>
               </div>
-              <span class="section-tag">inferred operational view</span>
             </div>
-            <div class="network-map{% if not network_clusters %} network-map-empty{% endif %}">
-              <div class="network-rings" aria-hidden="true"></div>
-              <article class="command-core">
-                <span class="eyebrow">Command Core</span>
-                <h3>{{ app_name }}</h3>
-                <p class="core-line">
-                  {{ snapshot.totals.active }} active unit{% if snapshot.totals.active != 1 %}s{% endif %}
-                  across {{ snapshot.by_phase | length }} tracked phase lanes.
-                </p>
-                <div class="core-grid">
-                  <div>
-                    <span class="label">Environment</span>
-                    <p>{{ environment }}</p>
-                  </div>
-                  <div>
-                    <span class="label">Recent Orders</span>
-                    <p>{{ recent_commands | length }}</p>
-                  </div>
-                  <div>
-                    <span class="label">Conflict Watch</span>
-                    <p>{{ snapshot.conflicts | length }}</p>
-                  </div>
-                  <div>
-                    <span class="label">Focus Unit</span>
-                    <p>{% if selected_worker %}{{ selected_worker.worker_id }}{% else %}none{% endif %}</p>
-                  </div>
-                </div>
-              </article>
-
-              {% if network_clusters %}
-              <div class="relay-grid">
-                {% for cluster in network_clusters %}
-                <article class="relay-card phase-{{ cluster.phase.value }}">
-                  <div class="relay-header">
-                    <span class="note-phase">phase relay</span>
-                    <span class="pill">{{ cluster.count }}</span>
-                  </div>
-                  <h3>{{ cluster.phase.value }}</h3>
-                  <p class="relay-copy">{{ cluster.label }}</p>
-                  <div class="unit-list">
-                    {% for unit in cluster.units %}
-                    <a class="unit-node freshness-{{ unit.freshness.state }}{% if unit.selected %} unit-node-selected{% endif %}" href="/?worker={{ unit.worker.worker_id }}#control-pane">
-                      <span class="unit-name">{{ unit.worker.worker_id }}</span>
-                      <span class="unit-phase">{{ unit.worker.updated_at | relative_time }}</span>
-                    </a>
-                    {% endfor %}
-                  </div>
-                  {% if cluster.overflow %}
-                  <p class="muted-text">+{{ cluster.overflow }} more units in this relay</p>
-                  {% endif %}
-                </article>
-                {% endfor %}
-              </div>
-              {% else %}
-              <article class="relay-empty">
-                <h3>No units on the field</h3>
-                <p>Use Self Report Intake to register a worker, then this network view will project its phase and freshness automatically.</p>
-              </article>
-              {% endif %}
-            </div>
-          </article>
-
-          <article class="panel">
-            <div class="section-head">
-              <div>
-                <h2>Operational Sectors</h2>
-                <p>Lifecycle lanes, still grouped by the canonical worker phases.</p>
-              </div>
-              <span class="section-tag">real store data</span>
-            </div>
-            <div class="phase-grid">
-              {% for phase in phase_order %}
-              <article class="phase-column">
-                <div class="phase-header">
-                  <h3>{{ phase.value }}</h3>
-                  <span class="pill">{{ snapshot.by_phase[phase] | length }}</span>
-                </div>
-                {% if snapshot.by_phase[phase] %}
-                <div class="worker-list">
-                  {% for worker in snapshot.by_phase[phase] %}
-                  {% set freshness = worker_states[worker.worker_id] %}
-                  <article class="worker-card phase-{{ phase.value }} freshness-{{ freshness.state }}{% if selected_worker_id == worker.worker_id %} worker-card-selected{% endif %}">
-                    <div class="worker-head">
-                      <div>
-                        <a class="worker-link" href="/?worker={{ worker.worker_id }}#control-pane">{{ worker.worker_id }}</a>
-                        <p class="timestamp">{{ worker.updated_at | relative_time }}</p>
-                      </div>
-                      <span class="freshness-pill freshness-pill-{{ freshness.state }}">{{ freshness.label }}</span>
-                    </div>
-                    <p class="status-line">{{ worker.status_line }}</p>
-                    <div class="chip-row">
-                      {% if worker.branch %}
-                      <span class="meta-chip"><strong>branch</strong> <code>{{ worker.branch }}</code></span>
-                      {% endif %}
-                      {% if worker.owned_artifact %}
-                      <span class="meta-chip"><strong>artifact</strong> <code>{{ worker.owned_artifact }}</code></span>
-                      {% endif %}
-                    </div>
-                    <p class="repo-line"><strong>repo</strong> <code>{{ worker.repo_path }}</code></p>
-                    {% if worker.next_irreversible_step %}
-                    <p class="next-step"><strong>Next</strong> {{ worker.next_irreversible_step }}</p>
-                    {% endif %}
-                    {% if worker.blocker %}
-                    <p class="blocker"><strong>Blocker</strong> {{ worker.blocker }}</p>
-                    {% endif %}
-                    {% if worker.last_note %}
-                    <div class="note">
-                      <span class="note-phase">{{ worker.last_note.phase.value }}</span>
-                      <p>{{ worker.last_note.note }}</p>
-                    </div>
-                    {% endif %}
-                    {% if worker.pr_url %}
-                    <p class="pr-link"><a href="{{ worker.pr_url }}">PR</a></p>
-                    {% endif %}
-                  </article>
-                  {% endfor %}
-                </div>
-                {% else %}
-                <p class="empty-state">No units in this sector.</p>
-                {% endif %}
-              </article>
+            <div class="saved-view-list">
+              {% for view in supervision.saved_views %}
+              <a class="saved-view{% if view.selected %} saved-view-selected{% endif %}" href="/?view=missions&saved_view={{ view.key }}{% if supervision.search_active %}&q={{ supervision.search_query }}{% endif %}">
+                {{ view.label }}
+              </a>
               {% endfor %}
             </div>
-          </article>
+          </section>
 
-          <article class="panel control-panel" id="control-pane">
-            <div class="section-head">
-              <div>
-                <h2>Focus Dossier</h2>
-                <p>Selected worker detail, transitions, and notes.</p>
-              </div>
-              <span class="section-tag">selected worker</span>
+          <section class="rail-panel metrics-panel">
+            <div class="metric-block">
+              <span class="label">Missions</span>
+              <strong>{{ supervision.summary.missions }}</strong>
             </div>
-            {% if selected_worker %}
-            {% set selected_freshness = worker_states[selected_worker.worker_id] %}
-            <article class="focus-card freshness-{{ selected_freshness.state }}">
-              <div class="focus-card-head">
-                <div>
-                  <span class="eyebrow">{{ selected_worker.phase.value }}</span>
-                  <h3>{{ selected_worker.worker_id }}</h3>
-                </div>
-                <span class="freshness-pill freshness-pill-{{ selected_freshness.state }}">{{ selected_freshness.label }}</span>
-              </div>
-              <p class="focus-line">{{ selected_worker.status_line }}</p>
-              <div class="focus-grid">
-                <div>
-                  <span class="label">Repo</span>
-                  <p><code>{{ selected_worker.repo_path }}</code></p>
-                </div>
-                <div>
-                  <span class="label">Branch</span>
-                  <p>{% if selected_worker.branch %}<code>{{ selected_worker.branch }}</code>{% else %}<span class="muted-text">none</span>{% endif %}</p>
-                </div>
-                <div>
-                  <span class="label">Worktree</span>
-                  <p>{% if selected_worker.worktree %}<code>{{ selected_worker.worktree }}</code>{% else %}<span class="muted-text">none</span>{% endif %}</p>
-                </div>
-                <div>
-                  <span class="label">Artifact</span>
-                  <p>{% if selected_worker.owned_artifact %}<code>{{ selected_worker.owned_artifact }}</code>{% else %}<span class="muted-text">none</span>{% endif %}</p>
-                </div>
-              </div>
-              {% if selected_worker.next_irreversible_step %}
-              <p class="next-step"><strong>Next irreversible step</strong> {{ selected_worker.next_irreversible_step }}</p>
-              {% endif %}
-              {% if selected_worker.blocker %}
-              <p class="blocker"><strong>Blocker</strong> {{ selected_worker.blocker }}</p>
-              {% endif %}
-              {% if selected_worker.pr_url %}
-              <p class="pr-link"><a href="{{ selected_worker.pr_url }}">Open PR</a></p>
-              {% endif %}
-            </article>
+            <div class="metric-block">
+              <span class="label">Attention</span>
+              <strong>{{ supervision.summary.attention }}</strong>
+            </div>
+            <div class="metric-block">
+              <span class="label">Workers</span>
+              <strong>{{ supervision.summary.workers }}</strong>
+            </div>
+            <div class="metric-block">
+              <span class="label">Merge Ready</span>
+              <strong>{{ supervision.summary.merge_ready }}</strong>
+            </div>
+          </section>
+        </aside>
 
-            <div class="detail-grid">
-              <div class="detail-section">
-                <div class="section-head section-head-tight">
-                  <h3>Phase Trail</h3>
-                  <p>{{ selected_worker.transitions | length }} transition{% if selected_worker.transitions | length != 1 %}s{% endif %}</p>
-                </div>
-                <div class="timeline">
-                  {% for transition in selected_worker.transitions %}
-                  <article class="timeline-card">
-                    <div class="timeline-head">
-                      <div class="timeline-title">
-                        {% if transition.previous_phase %}
-                        <span>{{ transition.previous_phase.value }}</span>
-                        <span class="timeline-arrow">-></span>
-                        {% endif %}
-                        <strong>{{ transition.current_phase.value }}</strong>
+        <section class="main-canvas">
+          <section class="canvas-head">
+            <div>
+              <p class="eyebrow">Primary canvas</p>
+              <h2>Mission Workspace</h2>
+              <p class="canvas-copy">Scan missions, isolate exceptions, and drill inline before opening a worker dossier.</p>
+            </div>
+            <div class="canvas-meta">
+              <span class="meta-chip">state <code>{{ data_dir }}/overlord.db</code></span>
+              <span class="meta-chip">roots <code>{{ allowed_repo_roots | join(", ") }}</code></span>
+            </div>
+          </section>
+
+          {% if supervision.current_view == "missions" %}
+          <section class="canvas-panel">
+            <div class="section-head section-head-row">
+              <div>
+                <h2>Mission Table</h2>
+                <p>One row per mission, merge ladder separate from execution phase.</p>
+              </div>
+              <span class="section-tag">{{ supervision.saved_view.replace("-", " ") }}</span>
+            </div>
+            {% if supervision.mission_rows %}
+            <div class="mission-table">
+              {% for mission in supervision.mission_rows %}
+              <details class="mission-row{% if mission.selected %} mission-row-selected{% endif %}"{% if mission.selected %} open{% endif %}>
+                <summary>
+                  <div class="mission-summary">
+                    <div class="mission-primary">
+                      <div class="mission-title-row">
+                        <span class="owner-pill">{{ mission.owner }}</span>
+                        <h3>{{ mission.goal }}</h3>
                       </div>
-                      <span class="timestamp">{{ timestamp_format(transition.created_at) }}</span>
+                      <p class="repo-line"><strong>{{ mission.repo_name }}</strong> <code>{{ mission.repo_path }}</code></p>
                     </div>
-                    <p>{{ transition.status_line }}</p>
-                    {% if transition.next_irreversible_step %}
-                    <p class="next-step"><strong>Next</strong> {{ transition.next_irreversible_step }}</p>
-                    {% endif %}
-                    {% if transition.blocker %}
-                    <p class="blocker"><strong>Blocker</strong> {{ transition.blocker }}</p>
-                    {% endif %}
-                    {% if transition.note %}
-                    <p class="timeline-note">{{ transition.note }}</p>
-                    {% endif %}
-                  </article>
-                  {% endfor %}
-                </div>
-              </div>
-
-              <div class="detail-section">
-                <div class="section-head section-head-tight">
-                  <h3>Phase Notes</h3>
-                  <p>Short notes grouped by phase.</p>
-                </div>
-                {% if selected_phase_notes %}
-                <div class="phase-note-groups">
-                  {% for group in selected_phase_notes %}
-                  <article class="phase-note-group">
-                    <div class="phase-note-header">
-                      <span class="note-phase">{{ group.phase.value }}</span>
-                      <span class="timestamp">{{ group.notes | length }} note{% if group.notes | length != 1 %}s{% endif %}</span>
+                    <div class="mission-stats">
+                      <span><strong>{{ mission.worker_count }}</strong> total</span>
+                      <span><strong>{{ mission.active_workers }}</strong> active</span>
+                      <span><strong>{{ mission.blocked_workers }}</strong> blocked</span>
+                      <span><strong>{{ mission.stale_workers }}</strong> stale</span>
+                      <span><strong>{{ mission.ready_workers }}</strong> ready</span>
                     </div>
-                    <div class="phase-note-list">
-                      {% for note in group.notes %}
-                      <article class="phase-note-card">
-                        <p class="timestamp">{{ timestamp_format(note.created_at) }}</p>
-                        <p>{{ note.note }}</p>
-                      </article>
+                    <div class="mission-recency">
+                      <span class="label">Latest event</span>
+                      <strong>{{ mission.latest_event_label }}</strong>
+                    </div>
+                    <div class="mission-merge">
+                      <span class="label">Merge ladder</span>
+                      <strong>{{ mission.merge_summary }}</strong>
+                    </div>
+                  </div>
+                  <div class="mission-summary-lower">
+                    <div class="badge-row">
+                      {% for badge in mission.exception_badges %}
+                      <span class="badge badge-{{ badge.tone }}">{{ badge.label }}</span>
+                      {% endfor %}
+                      <span class="badge badge-status">{{ mission.status_label }}</span>
+                    </div>
+                    <div class="fanout-strip">
+                      {% for group in mission.fanout_strip %}
+                      <div class="fanout-group">
+                        <span class="fanout-label">{{ group.label }}</span>
+                        <div class="fanout-workers">
+                          {% for worker in group.workers %}
+                          <span class="worker-chip worker-chip-{{ worker.freshness_state }}">{{ worker.worker_id }}</span>
+                          {% endfor %}
+                          {% if group.overflow %}
+                          <span class="worker-chip worker-chip-overflow">+{{ group.overflow }} more</span>
+                          {% endif %}
+                        </div>
+                      </div>
                       {% endfor %}
                     </div>
-                  </article>
-                  {% endfor %}
+                  </div>
+                </summary>
+
+                <div class="mission-detail">
+                  <div class="worker-grid">
+                    <section class="detail-card">
+                      <div class="section-head">
+                        <div>
+                          <h3>Worker Fanout</h3>
+                          <p>Grouped workers with direct manager drilldown.</p>
+                        </div>
+                      </div>
+                      <div class="worker-grid-list">
+                        {% for worker in mission.workers %}
+                        <a class="worker-tile worker-tile-{{ worker.freshness_state }}{% if worker.selected %} worker-tile-selected{% endif %}" href="/?view=missions&saved_view={{ supervision.saved_view }}&mission={{ mission.id }}&worker={{ worker.worker_id }}{% if supervision.search_active %}&q={{ supervision.search_query }}{% endif %}">
+                          <div class="worker-tile-head">
+                            <strong>{{ worker.worker_id }}</strong>
+                            <span class="badge badge-merge">{{ worker.merge_label }}</span>
+                          </div>
+                          <p>{{ worker.status_line }}</p>
+                          <p class="subtle">{{ worker.phase_label }} · {{ worker.updated_label }}</p>
+                          {% if worker.blocker %}
+                          <p class="blocker-line">{{ worker.blocker }}</p>
+                          {% endif %}
+                          {% if worker.branch %}
+                          <p class="mono-line"><code>{{ worker.branch }}</code></p>
+                          {% endif %}
+                        </a>
+                        {% endfor %}
+                      </div>
+                    </section>
+
+                    <section class="detail-card">
+                      <div class="section-head">
+                        <div>
+                          <h3>Mission Timeline</h3>
+                          <p>Compressed supervision events only.</p>
+                        </div>
+                      </div>
+                      {% if mission.timeline %}
+                      <div class="timeline-list">
+                        {% for event in mission.timeline %}
+                        <article class="timeline-entry">
+                          <div class="timeline-top">
+                            <span class="badge badge-status">{{ event.label }}</span>
+                            <span class="subtle">{{ event.timestamp | relative_time }}</span>
+                          </div>
+                          <p>{{ event.summary }}</p>
+                          {% if event.worker_id %}
+                          <p class="mono-line"><code>{{ event.worker_id }}</code></p>
+                          {% endif %}
+                        </article>
+                        {% endfor %}
+                      </div>
+                      {% else %}
+                      <p class="empty-state">No mission events yet.</p>
+                      {% endif %}
+                    </section>
+                  </div>
+
+                  {% if mission.selected and selected_worker %}
+                  <div class="dossier-grid">
+                    <section class="detail-card dossier-card">
+                      <div class="section-head">
+                        <div>
+                          <h3>Worker Dossier</h3>
+                          <p>Current state, next irreversible step, blocker, and merge posture.</p>
+                        </div>
+                      </div>
+                      <div class="dossier-head">
+                        <div>
+                          <p class="eyebrow">{{ selected_worker.phase.value }}</p>
+                          <h3>{{ selected_worker.worker_id }}</h3>
+                        </div>
+                        <span class="badge badge-{{ supervision.worker_states[selected_worker.worker_id].state }}">{{ supervision.worker_states[selected_worker.worker_id].label }}</span>
+                      </div>
+                      <p>{{ selected_worker.status_line }}</p>
+                      <div class="dossier-meta">
+                        <div><span class="label">Repo</span><p><code>{{ selected_worker.repo_path }}</code></p></div>
+                        <div><span class="label">Branch</span><p>{% if selected_worker.branch %}<code>{{ selected_worker.branch }}</code>{% else %}none{% endif %}</p></div>
+                        <div><span class="label">Worktree</span><p>{% if selected_worker.worktree %}<code>{{ selected_worker.worktree }}</code>{% else %}none{% endif %}</p></div>
+                        <div><span class="label">Artifact</span><p>{% if selected_worker.owned_artifact %}<code>{{ selected_worker.owned_artifact }}</code>{% else %}none{% endif %}</p></div>
+                      </div>
+                      {% if selected_worker.next_irreversible_step %}
+                      <p class="next-step"><strong>Next irreversible step</strong> {{ selected_worker.next_irreversible_step }}</p>
+                      {% endif %}
+                      {% if selected_worker.blocker %}
+                      <p class="blocker-line"><strong>Blocker</strong> {{ selected_worker.blocker }}</p>
+                      {% endif %}
+                      {% if selected_worker.pr_url %}
+                      <p><a href="{{ selected_worker.pr_url }}">Open PR</a></p>
+                      {% endif %}
+                    </section>
+
+                    <section class="detail-card">
+                      <div class="section-head">
+                        <div>
+                          <h3>Worker Timeline</h3>
+                          <p>State transitions kept separate from notes.</p>
+                        </div>
+                      </div>
+                      <div class="timeline-list">
+                        {% for transition in selected_worker.transitions[:8] %}
+                        <article class="timeline-entry">
+                          <div class="timeline-top">
+                            <span class="badge badge-status">{{ transition.current_phase.value }}</span>
+                            <span class="subtle">{{ timestamp_format(transition.created_at) }}</span>
+                          </div>
+                          <p>{{ transition.status_line }}</p>
+                          {% if transition.next_irreversible_step %}
+                          <p class="next-step"><strong>Next</strong> {{ transition.next_irreversible_step }}</p>
+                          {% endif %}
+                          {% if transition.note %}
+                          <p class="subtle">{{ transition.note }}</p>
+                          {% endif %}
+                        </article>
+                        {% endfor %}
+                      </div>
+                    </section>
+
+                    <section class="detail-card">
+                      <div class="section-head">
+                        <div>
+                          <h3>Phase Notes</h3>
+                          <p>High-signal notes by lifecycle phase.</p>
+                        </div>
+                      </div>
+                      {% if selected_phase_notes %}
+                      <div class="phase-note-groups">
+                        {% for group in selected_phase_notes %}
+                        <article class="phase-note-group">
+                          <div class="timeline-top">
+                            <span class="badge badge-status">{{ group.phase.value }}</span>
+                            <span class="subtle">{{ group.notes | length }} notes</span>
+                          </div>
+                          {% for note in group.notes[:3] %}
+                          <p>{{ note.note }}</p>
+                          {% endfor %}
+                        </article>
+                        {% endfor %}
+                      </div>
+                      {% else %}
+                      <p class="empty-state">No phase notes yet.</p>
+                      {% endif %}
+                    </section>
+                  </div>
+                  {% endif %}
                 </div>
-                {% else %}
-                <p class="empty-state">No phase notes for this worker yet.</p>
-                {% endif %}
-              </div>
+              </details>
+              {% endfor %}
             </div>
             {% else %}
-            <p class="empty-state">No worker selected yet.</p>
+            <p class="empty-state">No missions match the current filter.</p>
             {% endif %}
-          </article>
-        </section>
+          </section>
+          {% endif %}
 
-        <section class="rail">
-          <article class="panel" id="dispatch-pane">
+          {% if supervision.current_view == "board" %}
+          <section class="canvas-panel">
             <div class="section-head">
               <div>
-                <h2>General Dispatch</h2>
-                <p>Issue one concrete order and launch a real <code>codex exec</code> general prompt.</p>
+                <h2>Mission Board</h2>
+                <p>Operational grouping by supervision outcome.</p>
               </div>
-              <span class="section-tag">operator action</span>
             </div>
-            {% if dispatch_status == "launched" %}
-            <div class="banner banner-success">
-              <strong>Launched.</strong> The general order was handed to Codex and logged under <code>data/dispatches</code>.
-            </div>
-            {% endif %}
-            {% if dispatch_error %}
-            <div class="banner banner-error">
-              <strong>Rejected.</strong> {{ dispatch_error }}
-            </div>
-            {% endif %}
-            <form class="report-form" action="/dispatch" method="post">
-              <div class="form-grid">
-                <label>
-                  <span class="label">General Worker ID</span>
-                  <input name="general_worker_id" value="{{ dispatch_defaults.general_worker_id }}" placeholder="general-20260315-overlord" required>
-                </label>
-                <label>
-                  <span class="label">Branch Hint</span>
-                  <input name="branch_hint" value="{{ dispatch_defaults.branch_hint }}" placeholder="feat/localhost-mvp">
-                </label>
-                <label class="form-span-2">
-                  <span class="label">Repo Path</span>
-                  <input name="repo_path" value="{{ dispatch_defaults.repo_path }}" placeholder="/Users/matthewschwartz/projects/overlord" required>
-                </label>
-                <label class="form-span-2">
-                  <span class="label">Operator Instruction</span>
-                  <textarea name="operator_instruction" rows="5" placeholder="Finish the localhost MVP, verify it with pytest, and hand back the PR URL." required></textarea>
-                </label>
-              </div>
-              <div class="form-actions">
-                <button type="submit">Launch General</button>
-                <p class="muted-text">Orders stay server-rendered, local-first, and visible in Recent Orders.</p>
-              </div>
-            </form>
-          </article>
-
-          <article class="panel" id="self-report">
-            <div class="section-head">
-              <div>
-                <h2>Self Report Intake</h2>
-                <p>Delegated workers can post one transition at a time without a separate client.</p>
-              </div>
-              <span class="section-tag">worker intake</span>
-            </div>
-            {% if report_status == "accepted" %}
-            <div class="banner banner-success">
-              <strong>Accepted.</strong> The army state was updated and the board will refresh automatically.
-            </div>
-            {% endif %}
-            {% if report_error %}
-            <div class="banner banner-error">
-              <strong>Rejected.</strong> {{ report_error }}
-            </div>
-            {% endif %}
-            <form class="report-form" action="/report" method="post">
-              <div class="form-grid">
-                <label>
-                  <span class="label">Worker ID</span>
-                  <input name="worker_id" value="{{ report_defaults.worker_id }}" placeholder="worker-20260315-overlord-agent-a" required>
-                </label>
-                <label>
-                  <span class="label">Worker Token</span>
-                  <input name="worker_token" type="password" placeholder="worker-scoped secret" required>
-                </label>
-                <label>
-                  <span class="label">Current Phase</span>
-                  <select name="current_phase" required>
-                    {% for phase_value in phase_values %}
-                    <option value="{{ phase_value }}"{% if report_defaults.current_phase == phase_value %} selected{% endif %}>{{ phase_value }}</option>
-                    {% endfor %}
-                  </select>
-                </label>
-                <label>
-                  <span class="label">Previous Phase</span>
-                  <select name="previous_phase">
-                    <option value="">none</option>
-                    {% for phase_value in phase_values %}
-                    <option value="{{ phase_value }}"{% if report_defaults.previous_phase == phase_value %} selected{% endif %}>{{ phase_value }}</option>
-                    {% endfor %}
-                  </select>
-                </label>
-                <label class="form-span-2">
-                  <span class="label">Status Line</span>
-                  <input name="status_line" placeholder="patching the battle-network relay cards" required>
-                </label>
-                <label class="form-span-2">
-                  <span class="label">Repo Path</span>
-                  <input name="repo_path" value="{{ report_defaults.repo_path }}" placeholder="/Users/matthewschwartz/projects/overlord" required>
-                </label>
-                <label>
-                  <span class="label">Branch</span>
-                  <input name="branch" value="{{ report_defaults.branch }}" placeholder="feat/overlord-mvp">
-                </label>
-                <label>
-                  <span class="label">Worktree</span>
-                  <input name="worktree" value="{{ report_defaults.worktree }}" placeholder="/tmp/overlord-worker-a">
-                </label>
-                <label class="form-span-2">
-                  <span class="label">Owned Artifact</span>
-                  <input name="owned_artifact" value="{{ report_defaults.owned_artifact }}" placeholder="overlord/templates/index.html">
-                </label>
-                <label class="form-span-2">
-                  <span class="label">Next Irreversible Step</span>
-                  <input name="next_irreversible_step" placeholder="run pytest and open the MVP PR">
-                </label>
-                <label class="form-span-2">
-                  <span class="label">Blocker</span>
-                  <input name="blocker" placeholder="waiting on repo instruction clarification">
-                </label>
-                <label class="form-span-2">
-                  <span class="label">Pull Request URL</span>
-                  <input name="pr_url" type="url" placeholder="https://github.com/mvs5465-test/overlord/pull/1">
-                </label>
-                <label class="form-span-2">
-                  <span class="label">Short Note</span>
-                  <textarea name="note" rows="3" placeholder="kept the app server-rendered and reshaped only the operator surface"></textarea>
-                </label>
-              </div>
-              <div class="form-actions">
-                <button type="submit">Post Self Report</button>
-                <p class="muted-text">Initial registrations use <code>current_phase=assigned</code> with <code>previous_phase=none</code>.</p>
-              </div>
-            </form>
-          </article>
-
-          <article class="panel">
-            <div class="section-head">
-              <div>
-                <h2>Recent Orders</h2>
-                <p>General dispatch history with pid and local log paths.</p>
-              </div>
-              <span class="section-tag">command log</span>
-            </div>
-            {% if recent_commands %}
-            <div class="note-feed">
-              {% for command in recent_commands %}
-              <article class="feed-card">
-                <div class="worker-head">
-                  <h4>{{ command.general_worker_id }}</h4>
-                  <span class="timestamp">{{ command.created_at | relative_time }}</span>
+            <div class="board-grid">
+              {% for column in supervision.mission_board %}
+              <section class="board-column">
+                <div class="board-head">
+                  <h3>{{ column.label }}</h3>
+                  <span class="meta-pill">{{ column.missions | length }}</span>
                 </div>
-                <span class="note-phase">{{ command.status.value }}</span>
-                <p>{{ command.operator_instruction }}</p>
-                <p class="repo-line"><strong>repo</strong> <code>{{ command.repo_path }}</code></p>
-                <p class="repo-line"><strong>pid</strong> <code>{{ command.pid }}</code></p>
-                {% if command.branch_hint %}
-                <p class="repo-line"><strong>branch</strong> <code>{{ command.branch_hint }}</code></p>
-                {% endif %}
-                <p class="repo-line"><strong>log</strong> <code>{{ command.log_path }}</code></p>
+                {% for mission in column.missions %}
+                <a class="board-card" href="/?view=missions&saved_view={{ supervision.saved_view }}&mission={{ mission.id }}">
+                  <strong>{{ mission.goal }}</strong>
+                  <p>{{ mission.repo_name }} · {{ mission.owner }}</p>
+                  <p class="subtle">{{ mission.merge_summary }}</p>
+                </a>
+                {% endfor %}
+              </section>
+              {% endfor %}
+            </div>
+          </section>
+          {% endif %}
+
+          {% if supervision.current_view == "fanout" %}
+          <section class="canvas-panel">
+            <div class="section-head">
+              <div>
+                <h2>Fanout Map</h2>
+                <p>Compact mission clusters by phase, not a graph-first home screen.</p>
+              </div>
+            </div>
+            <div class="fanout-map">
+              {% for cluster in supervision.fanout_clusters %}
+              <article class="fanout-card">
+                <div class="board-head">
+                  <strong>{{ cluster.repo_name }}</strong>
+                  <span class="badge badge-status">{{ cluster.status_label }}</span>
+                </div>
+                <p>{{ cluster.goal }}</p>
+                <p class="subtle">{{ cluster.owner }} · {{ cluster.worker_count }} workers</p>
+                <div class="phase-pill-row">
+                  {% for phase in cluster.phase_counts %}
+                  <span class="meta-chip">{{ phase.label }}: {{ phase.count }}</span>
+                  {% endfor %}
+                </div>
+              </article>
+              {% endfor %}
+            </div>
+          </section>
+          {% endif %}
+
+          {% if supervision.current_view == "dispatches" %}
+          <section class="canvas-panel">
+            <div class="section-head">
+              <div>
+                <h2>Dispatch Log</h2>
+                <p>Intent, owner, repo, launch context, and inferred mission progress.</p>
+              </div>
+            </div>
+            {% if supervision.dispatch_rows %}
+            <div class="list-table">
+              {% for dispatch in supervision.dispatch_rows %}
+              <article class="list-row">
+                <div>
+                  <strong>{{ dispatch.objective }}</strong>
+                  <p class="subtle">{{ dispatch.owner }} · {{ dispatch.repo_name }} · {{ dispatch.progress }}</p>
+                </div>
+                <div class="list-meta">
+                  {% if dispatch.branch_hint %}<span class="meta-chip"><code>{{ dispatch.branch_hint }}</code></span>{% endif %}
+                  <span class="meta-chip"><code>{{ dispatch.prompt_path }}</code></span>
+                  <span class="meta-chip"><code>{{ dispatch.log_path }}</code></span>
+                  <span class="meta-chip">pid {{ dispatch.pid }}</span>
+                </div>
               </article>
               {% endfor %}
             </div>
             {% else %}
-            <p class="empty-state">No general orders launched yet.</p>
+            <p class="empty-state">No dispatches yet.</p>
             {% endif %}
-          </article>
+          </section>
+          {% endif %}
 
-          <article class="panel">
+          {% if supervision.current_view == "conflicts" %}
+          <section class="canvas-panel">
             <div class="section-head">
               <div>
-                <h2>Conflict Watch</h2>
-                <p>Repo, branch, worktree, and artifact overlaps.</p>
+                <h2>Conflicts</h2>
+                <p>Grouped by mission first, then repo path, branch, worktree, and artifact collisions.</p>
               </div>
-              <span class="section-tag">collision scan</span>
             </div>
-            {% if snapshot.conflicts %}
-            <div class="conflict-list">
-              {% for conflict in snapshot.conflicts %}
-              <article class="conflict-card">
-                <span class="label">{{ conflict.field }}</span>
-                <p><code>{{ conflict.value }}</code></p>
-                <p>{{ conflict.worker_ids | join(", ") }}</p>
+            {% if supervision.conflict_groups %}
+            <div class="list-table">
+              {% for group in supervision.conflict_groups %}
+              <article class="conflict-group">
+                <div class="board-head">
+                  <strong>{{ group.goal }}</strong>
+                  <span class="meta-pill">{{ group.repo_name }}</span>
+                </div>
+                {% for conflict in group.conflicts %}
+                <div class="conflict-item">
+                  <p><strong>{{ conflict.field }}</strong> <code>{{ conflict.value }}</code></p>
+                  <p class="subtle">{{ conflict.worker_ids | join(", ") }}</p>
+                </div>
+                {% endfor %}
               </article>
               {% endfor %}
             </div>
             {% else %}
             <p class="empty-state">No active ownership conflicts.</p>
             {% endif %}
-          </article>
+          </section>
+          {% endif %}
 
-          <article class="panel">
+          {% if supervision.current_view == "workers" %}
+          <section class="canvas-panel">
             <div class="section-head">
               <div>
-                <h2>Recent Notes</h2>
-                <p>Short phase breadcrumbs, not a chat log.</p>
+                <h2>Worker Roster</h2>
+                <p>Lifecycle visible in a flat scan when needed.</p>
               </div>
-              <span class="section-tag">signal feed</span>
             </div>
-            {% if snapshot.recent_notes %}
-            <div class="note-feed">
-              {% for note in snapshot.recent_notes %}
-              <article class="feed-card">
-                <div class="worker-head">
-                  <h4>{{ note.worker_id }}</h4>
-                  <span class="timestamp">{{ note.created_at | relative_time }}</span>
+            {% if supervision.worker_rows %}
+            <div class="list-table">
+              {% for worker in supervision.worker_rows %}
+              <a class="list-row" href="/?view=missions&saved_view={{ supervision.saved_view }}&mission={{ worker.mission_id }}&worker={{ worker.worker_id }}">
+                <div>
+                  <strong>{{ worker.worker_id }}</strong>
+                  <p class="subtle">{{ worker.mission_owner }} · {{ worker.mission_goal }}</p>
                 </div>
-                <span class="note-phase">{{ note.phase.value }}</span>
-                <p>{{ note.note }}</p>
-              </article>
+                <div class="list-meta">
+                  <span class="badge badge-status">{{ worker.phase_label }}</span>
+                  <span class="badge badge-{{ worker.freshness_state }}">{{ worker.updated_label }}</span>
+                  <span class="badge badge-merge">{{ worker.merge_label }}</span>
+                  <span class="meta-chip"><code>{{ worker.repo_name }}</code></span>
+                </div>
+              </a>
               {% endfor %}
             </div>
             {% else %}
-            <p class="empty-state">No notes yet.</p>
+            <p class="empty-state">No workers tracked yet.</p>
             {% endif %}
-          </article>
+          </section>
+          {% endif %}
         </section>
-      </section>
+
+        <aside class="right-rail">
+          <section class="rail-panel">
+            <div class="section-head">
+              <div>
+                <h2>Attention Queue</h2>
+                <p>Manager-only exceptions sorted for action.</p>
+              </div>
+            </div>
+            {% if supervision.attention_items %}
+            <div class="attention-list">
+              {% for item in supervision.attention_items %}
+              <a class="attention-item" href="/?view=missions&saved_view=needs-attention&mission={{ item.mission_id }}">
+                <div class="timeline-top">
+                  <span class="badge badge-{{ item.kind }}">{{ item.label }}</span>
+                  <span class="subtle">{{ item.age }}</span>
+                </div>
+                <p>{{ item.reason }}</p>
+              </a>
+              {% endfor %}
+            </div>
+            {% else %}
+            <p class="empty-state">Nothing needs action right now.</p>
+            {% endif %}
+          </section>
+
+          <section class="rail-panel" id="dispatch-pane">
+            <div class="section-head">
+              <div>
+                <h2>Dispatch</h2>
+                <p>Compact launch surface for new delegated work.</p>
+              </div>
+            </div>
+            {% if dispatch_status == "launched" %}
+            <div class="banner banner-success"><strong>Launched.</strong> Dispatch logged under <code>data/dispatches</code>.</div>
+            {% endif %}
+            {% if dispatch_error %}
+            <div class="banner banner-error"><strong>Rejected.</strong> {{ dispatch_error }}</div>
+            {% endif %}
+            <form class="compact-form" action="/dispatch" method="post">
+              <label>
+                <span class="label">Owner</span>
+                <input name="general_worker_id" value="{{ dispatch_defaults.general_worker_id }}" required>
+              </label>
+              <label>
+                <span class="label">Repo Path</span>
+                <input name="repo_path" value="{{ dispatch_defaults.repo_path }}" required>
+              </label>
+              <label>
+                <span class="label">Branch Hint</span>
+                <input name="branch_hint" value="{{ dispatch_defaults.branch_hint }}">
+              </label>
+              <label>
+                <span class="label">Objective</span>
+                <textarea name="operator_instruction" rows="5" required placeholder="Ship the mission-first supervision rewrite, verify with pytest, and return the PR URL."></textarea>
+              </label>
+              <button type="submit">Launch Dispatch</button>
+            </form>
+            {% if recent_commands %}
+            <div class="timeline-list">
+              {% for command in recent_commands[:4] %}
+              <article class="timeline-entry">
+                <div class="timeline-top">
+                  <span class="badge badge-status">{{ command.general_worker_id }}</span>
+                  <span class="subtle">{{ command.created_at | relative_time }}</span>
+                </div>
+                <p>{{ command.operator_instruction }}</p>
+                <p class="mono-line"><code>{{ command.repo_path }}</code></p>
+                <p class="mono-line"><code>{{ command.log_path }}</code></p>
+              </article>
+              {% endfor %}
+            </div>
+            {% endif %}
+          </section>
+
+          <section class="rail-panel">
+            <div class="section-head">
+              <div>
+                <h2>Self Report Intake</h2>
+                <p>Manual worker updates still available.</p>
+              </div>
+            </div>
+            {% if report_status == "accepted" %}
+            <div class="banner banner-success"><strong>Accepted.</strong> Worker update accepted.</div>
+            {% endif %}
+            {% if report_error %}
+            <div class="banner banner-error"><strong>Rejected.</strong> {{ report_error }}</div>
+            {% endif %}
+            <form class="compact-form" action="/report" method="post">
+              <label><span class="label">Worker ID</span><input name="worker_id" value="{{ report_defaults.worker_id }}" required></label>
+              <label><span class="label">Worker Token</span><input name="worker_token" type="password" required></label>
+              <div class="split-fields">
+                <label><span class="label">Current Phase</span><select name="current_phase">{% for phase_value in phase_values %}<option value="{{ phase_value }}"{% if report_defaults.current_phase == phase_value %} selected{% endif %}>{{ phase_value }}</option>{% endfor %}</select></label>
+                <label><span class="label">Previous Phase</span><select name="previous_phase"><option value="">none</option>{% for phase_value in phase_values %}<option value="{{ phase_value }}"{% if report_defaults.previous_phase == phase_value %} selected{% endif %}>{{ phase_value }}</option>{% endfor %}</select></label>
+              </div>
+              <label><span class="label">Status Line</span><input name="status_line" required></label>
+              <label><span class="label">Repo Path</span><input name="repo_path" value="{{ report_defaults.repo_path }}" required></label>
+              <label><span class="label">Branch</span><input name="branch" value="{{ report_defaults.branch }}"></label>
+              <label><span class="label">Worktree</span><input name="worktree" value="{{ report_defaults.worktree }}"></label>
+              <label><span class="label">Owned Artifact</span><input name="owned_artifact" value="{{ report_defaults.owned_artifact }}"></label>
+              <label><span class="label">Next Irreversible Step</span><input name="next_irreversible_step"></label>
+              <label><span class="label">Blocker</span><input name="blocker"></label>
+              <label><span class="label">Pull Request URL</span><input name="pr_url" type="url"></label>
+              <label><span class="label">Short Note</span><textarea name="note" rows="3"></textarea></label>
+              <button type="submit">Post Report</button>
+            </form>
+          </section>
+
+          <section class="rail-panel" id="settings-panel">
+            <div class="section-head">
+              <div>
+                <h2>Settings</h2>
+                <p>Static environment context for this localhost control plane.</p>
+              </div>
+            </div>
+            <div class="settings-list">
+              <p><strong>Environment</strong> {{ environment }}</p>
+              <p><strong>Workspace</strong> {{ workspace }}</p>
+              <p><strong>Allowlist</strong> <code>{{ allowed_repo_roots | join(", ") }}</code></p>
+            </div>
+          </section>
+        </aside>
+      </div>
     </main>
   </body>
 </html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -130,13 +130,16 @@ def test_homepage_renders_live_dashboard(tmp_path: Path) -> None:
     response = client.get("/")
 
     assert response.status_code == 200
-    assert "Command theater" in response.text
+    assert "Mission supervision" in response.text
+    assert "Mission Workspace" in response.text
+    assert "Mission Table" in response.text
+    assert "Attention Queue" in response.text
     assert "worker-123" in response.text
-    assert "Battle Network" in response.text
-    assert "Focus Dossier" in response.text
+    assert "Worker Dossier" in response.text
+    assert "merge ladder" in response.text.lower()
     assert "Self Report Intake" in response.text
-    assert "General Dispatch" in response.text
-    assert "Phase Trail" in response.text
+    assert "Dispatch" in response.text
+    assert "Mission Timeline" in response.text
     assert "Phase Notes" in response.text
     assert "keeping api and persistence untouched" in response.text
 
@@ -158,6 +161,73 @@ def test_selected_worker_prefills_a_valid_next_transition(tmp_path: Path) -> Non
     assert response.status_code == 200
     assert '<option value="planned" selected>planned</option>' in response.text
     assert '<option value="scouting" selected>scouting</option>' in response.text
+
+
+def test_search_and_saved_view_keep_mission_focus(tmp_path: Path) -> None:
+    client = build_client(tmp_path)
+    register_worker(client, tmp_path)
+    transition_worker(
+        client,
+        tmp_path,
+        phase="scouting",
+        previous_phase="assigned",
+        status_line="reading repo instructions and app shape",
+        next_step="map mission grouping",
+        note="status is fresh and should appear in all active",
+    )
+    client.post(
+        "/api/workers/events",
+        json={
+            "worker_id": "worker-456",
+            "worker_token": "second-secret-token",
+            "current_phase": "assigned",
+            "previous_phase": None,
+            "repo_path": str(tmp_path / "second-repo"),
+            "status_line": "waiting in another repo",
+        },
+    )
+
+    response = client.get("/?view=missions&saved_view=all-active&q=worker-123")
+
+    assert response.status_code == 200
+    assert "worker-123" in response.text
+    assert "worker-456" not in response.text
+    assert "Saved Views" in response.text
+
+
+def test_merge_and_conflict_signals_render_in_mission_view(tmp_path: Path) -> None:
+    client = build_client(tmp_path)
+    register_worker(client, tmp_path)
+    transition_worker(
+        client,
+        tmp_path,
+        phase="scouting",
+        previous_phase="assigned",
+        status_line="reading repo instructions and app shape",
+        next_step="open a PR for review",
+    )
+    client.post(
+        "/api/workers/events",
+        json={
+            "worker_id": "worker-789",
+            "worker_token": "third-secret-token",
+            "current_phase": "assigned",
+            "previous_phase": None,
+            "repo_path": str(tmp_path),
+            "branch": "feat/control-plane-mvp",
+            "worktree": str(tmp_path / "worktree-2"),
+            "owned_artifact": "overlord/app.py",
+            "status_line": "approved and ready to merge",
+            "pr_url": "https://github.com/mvs5465-test/overlord/pull/9",
+        },
+    )
+
+    response = client.get("/?view=conflicts&saved_view=all-active")
+
+    assert response.status_code == 200
+    assert "approved" in response.text
+    assert "Conflicts" in response.text
+    assert "feat/control-plane-mvp" in response.text
 
 
 def test_worker_event_persists_and_project_current_state(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- replace the worker-flat dashboard with a mission-first supervision workspace
- add server-side mission projection, attention queue, merge ladder, and secondary board/fanout/conflict/worker views
- preserve dispatch and self-report write paths while updating tests for the new UX

## Verification
- .venv/bin/pytest