### PR TITLE
feat(ui): simplify supervision dashboard

### DIFF
--- a/overlord/static/styles.css
+++ b/overlord/static/styles.css
@@ -1,41 +1,26 @@
 :root {
-  --bg: #eef2f6;
-  --panel: #fbfcfd;
-  --panel-strong: #ffffff;
-  --panel-muted: #f4f7fa;
-  --line: #c9d3de;
-  --line-strong: #97a7b8;
-  --text: #102133;
-  --muted: #5d7286;
-  --blue: #0c63a8;
-  --blue-soft: #d9ebf8;
-  --red: #b23b31;
-  --red-soft: #f9dfdb;
-  --amber: #9a6408;
-  --amber-soft: #f8edd2;
-  --green: #197246;
-  --green-soft: #dbeedd;
-  --slate-soft: #e5ebf2;
-  --shadow: 0 18px 34px rgba(16, 33, 51, 0.08);
+  color-scheme: light;
+  --bg: #f5f3ee;
+  --panel: #fffdf8;
+  --line: #ddd6c8;
+  --text: #181613;
+  --muted: #6d665c;
+  --accent: #111111;
+  --success: #2f6a3f;
+  --error: #8a2f2f;
+  --shadow: 0 1px 0 rgba(17, 17, 17, 0.04);
 }
 
 * {
   box-sizing: border-box;
 }
 
-html {
-  scroll-behavior: smooth;
-}
-
 body {
   margin: 0;
-  min-height: 100vh;
-  font-family: "Manrope", "Segoe UI", sans-serif;
+  background: var(--bg);
   color: var(--text);
-  background:
-    linear-gradient(180deg, rgba(12, 99, 168, 0.06), transparent 26%),
-    linear-gradient(135deg, rgba(248, 237, 210, 0.55), transparent 38%),
-    var(--bg);
+  font-family: "Instrument Sans", sans-serif;
+  line-height: 1.45;
 }
 
 a {
@@ -43,600 +28,320 @@ a {
   text-decoration: none;
 }
 
-a:hover {
-  text-decoration: none;
-}
-
 code,
-.mono-line {
-  font-family: "IBM Plex Mono", "Space Mono", monospace;
-}
-
-h1,
-h2,
-h3,
-p {
-  margin: 0;
-}
-
-button,
 input,
+textarea,
 select,
-textarea {
+button {
   font: inherit;
 }
 
-button {
-  cursor: pointer;
+code {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.88rem;
 }
 
-.app-shell {
-  width: min(1600px, calc(100% - 1rem));
+.page {
+  width: min(1240px, calc(100vw - 32px));
   margin: 0 auto;
-  padding: 0.75rem 0 1rem;
+  padding: 28px 0 40px;
 }
 
-.topbar,
-.rail-panel,
-.canvas-panel,
-.board-card,
-.fanout-card,
-.list-row,
-.conflict-group,
-.mission-row,
-.worker-tile,
-.timeline-entry,
-.phase-note-group,
-.attention-item {
+.masthead,
+.toolbar,
+.summary-grid,
+.panel {
   border: 1px solid var(--line);
-  border-radius: 16px;
-  background: var(--panel-strong);
+  background: var(--panel);
   box-shadow: var(--shadow);
 }
 
-.topbar {
-  display: grid;
-  grid-template-columns: minmax(220px, 0.9fr) minmax(200px, 0.7fr) minmax(260px, 1fr);
-  gap: 0.9rem;
-  align-items: center;
-  padding: 1rem 1.1rem;
-  margin-bottom: 0.85rem;
+.masthead,
+.toolbar,
+.panel {
+  padding: 18px;
 }
 
-.brand-block h1 {
-  font-size: clamp(1.7rem, 2vw, 2.2rem);
-}
-
-.workspace-shell {
-  display: grid;
-  grid-template-columns: 220px minmax(0, 1fr) 330px;
-  gap: 0.85rem;
-  align-items: start;
-}
-
-.left-rail,
-.main-canvas,
-.right-rail,
-.rail-nav,
-.saved-view-list,
-.metrics-panel,
-.attention-list,
-.compact-form,
-.worker-grid-list,
-.timeline-list,
-.phase-note-groups,
-.board-grid,
-.fanout-map,
-.list-table,
-.settings-list {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.rail-nav .rail-link,
-.saved-view,
-.switch-link,
-.dispatch-cta {
-  transition: background-color 140ms ease, border-color 140ms ease, color 140ms ease, transform 140ms ease;
-}
-
-.rail-link,
-.saved-view,
-.switch-link,
-.dispatch-cta {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 2.3rem;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: var(--panel-strong);
-}
-
-.rail-link-accent,
-.saved-view-selected,
-.switch-link-selected,
-.dispatch-cta {
-  border-color: rgba(12, 99, 168, 0.28);
-  background: var(--blue-soft);
-  color: var(--blue);
-}
-
-.dispatch-cta {
-  font-weight: 700;
-}
-
-.topbar-meta,
-.view-switcher,
-.canvas-meta,
-.mission-stats,
-.badge-row,
-.fanout-workers,
-.timeline-top,
-.worker-tile-head,
-.board-head,
-.list-meta,
-.split-fields,
-.dossier-meta {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-.search-form {
-  grid-column: 3;
-}
-
-.search-box,
-.compact-form label {
-  display: grid;
-  gap: 0.25rem;
-}
-
-.search-box input,
-.compact-form input,
-.compact-form select,
-.compact-form textarea {
-  width: 100%;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  background: var(--panel-muted);
-  color: var(--text);
-  padding: 0.62rem 0.72rem;
-}
-
-.compact-form button {
-  border: 1px solid rgba(12, 99, 168, 0.28);
-  border-radius: 10px;
-  background: var(--blue);
-  color: #fff;
-  padding: 0.72rem 0.9rem;
-  font-weight: 700;
-}
-
-.label,
-.eyebrow,
-.subtle {
-  color: var(--muted);
-}
-
-.label,
-.eyebrow {
-  font-size: 0.76rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.subtle {
-  font-size: 0.9rem;
-}
-
-.meta-pill,
-.meta-chip,
-.badge,
-.owner-pill,
-.section-tag {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  font-size: 0.78rem;
-  font-weight: 700;
-}
-
-.meta-pill,
-.meta-chip,
-.section-tag {
-  padding: 0.34rem 0.62rem;
-  background: var(--panel-muted);
-  border: 1px solid var(--line);
-}
-
-.badge,
-.owner-pill {
-  padding: 0.28rem 0.56rem;
-}
-
-.badge-status,
-.owner-pill {
-  background: var(--slate-soft);
-  color: var(--text);
-}
-
-.badge-blocked,
-.badge-conflict,
-.badge-stale,
-.banner-error {
-  background: var(--red-soft);
-  color: var(--red);
-}
-
-.badge-review,
-.badge-merge,
-.badge-active,
-.banner-success {
-  background: var(--green-soft);
-  color: var(--green);
-}
-
-.badge-quiet {
-  background: var(--slate-soft);
-  color: var(--muted);
-}
-
-.badge-merge {
-  background: var(--blue-soft);
-  color: var(--blue);
-}
-
-.left-rail,
-.main-canvas,
-.right-rail {
-  min-width: 0;
-}
-
-.rail-panel,
-.canvas-panel {
-  padding: 0.9rem;
-}
-
-.canvas-head {
+.masthead {
   display: flex;
   justify-content: space-between;
-  gap: 0.9rem;
-  align-items: start;
-  margin-bottom: 0.75rem;
+  gap: 24px;
+  align-items: flex-start;
 }
 
-.canvas-copy {
-  margin-top: 0.35rem;
+.masthead h1,
+.section-head h2,
+.row-head h3,
+.detail-block h3,
+.subsection h3 {
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.lede,
+.muted,
+.section-head p,
+.empty-state {
   color: var(--muted);
+}
+
+.eyebrow,
+.label,
+dt {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.74rem;
+  color: var(--muted);
+}
+
+.masthead-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.masthead-meta span,
+.status,
+.chip,
+.tab {
+  border: 1px solid var(--line);
+  padding: 6px 10px;
+  background: #faf7f1;
+}
+
+.toolbar {
+  margin-top: 14px;
+  display: grid;
+  gap: 16px;
+}
+
+.search-form label,
+.form-stack label {
+  display: grid;
+  gap: 6px;
+}
+
+.search-form input,
+.form-stack input,
+.form-stack textarea,
+.form-stack select {
+  width: 100%;
+  border: 1px solid var(--line);
+  background: #fff;
+  color: var(--text);
+  padding: 10px 12px;
+  border-radius: 0;
+}
+
+.tab-row,
+.chip-row,
+.worker-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tab-selected,
+.chip-selected,
+.mission-row-selected,
+.list-row:hover,
+.worker-links a:hover {
+  border-color: var(--accent);
+}
+
+.summary-grid {
+  margin-top: 14px;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.summary-grid article {
+  padding: 14px 16px;
+  border-right: 1px solid var(--line);
+  min-height: 86px;
+}
+
+.summary-grid article:last-child {
+  border-right: 0;
+}
+
+.summary-grid strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 1.15rem;
+}
+
+.layout {
+  margin-top: 14px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.9fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.main-pane,
+.side-pane {
+  display: grid;
+  gap: 14px;
 }
 
 .section-head {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.75rem;
-  align-items: start;
-  margin-bottom: 0.75rem;
-}
-
-.section-head p {
-  margin-top: 0.25rem;
-  color: var(--muted);
-}
-
-.metric-block {
   display: grid;
-  gap: 0.25rem;
-  padding: 0.7rem;
+  gap: 4px;
+  margin-bottom: 14px;
+}
+
+.stack {
+  display: grid;
+  gap: 10px;
+}
+
+.compact-stack {
+  gap: 8px;
+}
+
+.mission-row,
+.list-row,
+.timeline-item {
   border: 1px solid var(--line);
-  border-radius: 12px;
-  background: var(--panel-muted);
-}
-
-.metric-block strong {
-  font-size: 1.35rem;
-}
-
-.mission-table {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.mission-row summary {
-  list-style: none;
-  cursor: pointer;
-  padding: 0.9rem;
-}
-
-.mission-row summary::-webkit-details-marker {
-  display: none;
-}
-
-.mission-row-selected {
-  border-color: rgba(12, 99, 168, 0.36);
-}
-
-.mission-summary {
-  display: grid;
-  grid-template-columns: minmax(260px, 2fr) repeat(3, minmax(120px, auto));
-  gap: 0.85rem;
-  align-items: start;
-}
-
-.mission-title-row {
-  display: flex;
-  gap: 0.55rem;
-  align-items: center;
-  flex-wrap: wrap;
-  margin-bottom: 0.35rem;
-}
-
-.mission-primary h3 {
-  font-size: 1.05rem;
-}
-
-.mission-summary-lower {
-  display: grid;
-  gap: 0.7rem;
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid var(--line);
-}
-
-.fanout-strip {
-  display: grid;
-  gap: 0.55rem;
-}
-
-.fanout-group {
-  display: flex;
-  gap: 0.55rem;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.fanout-label {
-  min-width: 120px;
-  font-size: 0.8rem;
-  font-weight: 700;
-  color: var(--muted);
-}
-
-.worker-chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.26rem 0.52rem;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  background: var(--panel-muted);
-  font-size: 0.8rem;
-}
-
-.worker-chip-active {
-  border-color: rgba(12, 99, 168, 0.2);
-  background: var(--blue-soft);
-}
-
-.worker-chip-quiet,
-.worker-chip-overflow {
-  color: var(--muted);
-}
-
-.worker-chip-stale {
-  border-color: rgba(178, 59, 49, 0.24);
-  background: var(--red-soft);
-}
-
-.mission-detail,
-.worker-grid,
-.dossier-grid {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.mission-detail {
-  padding: 0 0.9rem 0.9rem;
-}
-
-.worker-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.dossier-grid {
-  grid-template-columns: 1.2fr 1fr 0.9fr;
-}
-
-.detail-card {
-  padding: 0.85rem;
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  background: var(--panel-muted);
-}
-
-.worker-grid-list {
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.worker-tile {
-  padding: 0.8rem;
-}
-
-.worker-tile-selected,
-.worker-tile:hover,
-.attention-item:hover,
-.list-row:hover,
-.board-card:hover {
-  border-color: rgba(12, 99, 168, 0.32);
-  transform: translateY(-1px);
-}
-
-.worker-tile p,
-.timeline-entry p,
-.phase-note-group p,
-.attention-item p,
-.board-card p,
-.fanout-card p,
-.list-row p,
-.settings-list p,
-.conflict-item p {
-  margin-top: 0.25rem;
-}
-
-.worker-tile-stale,
-.badge-blocked,
-.blocker-line {
-  color: var(--red);
-}
-
-.worker-tile-quiet {
-  border-style: dashed;
-}
-
-.timeline-list {
-  max-height: 420px;
-  overflow: auto;
-}
-
-.timeline-entry,
-.phase-note-group,
-.attention-item,
-.board-card,
-.fanout-card,
-.conflict-item {
-  padding: 0.7rem;
-}
-
-.attention-item {
-  display: grid;
-  gap: 0.3rem;
-}
-
-.banner-success,
-.banner-error {
-  padding: 0.6rem 0.7rem;
-  border-radius: 12px;
-  font-weight: 600;
-}
-
-.board-grid {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.board-column {
-  display: grid;
-  gap: 0.65rem;
-  align-content: start;
-}
-
-.fanout-map {
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  background: #fff;
+  padding: 14px;
 }
 
 .list-row {
   display: flex;
   justify-content: space-between;
-  gap: 0.8rem;
-  padding: 0.8rem;
+  gap: 18px;
+  align-items: flex-start;
 }
 
-.conflict-group {
-  padding: 0.8rem;
+.list-row-static {
+  display: block;
 }
 
-.settings-list code,
-.repo-line code,
-.mono-line code,
-.meta-chip code {
-  font-size: 0.84em;
+.row-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
 }
 
-@media (max-width: 1180px) {
-  .workspace-shell {
-    grid-template-columns: 220px minmax(0, 1fr);
-  }
+.row-head h3,
+.detail-block h3 {
+  font-size: 1rem;
+}
 
-  .right-rail {
-    grid-column: 1 / -1;
-    display: grid;
+.status {
+  white-space: nowrap;
+}
+
+.worker-links a {
+  display: inline-block;
+  border: 1px solid var(--line);
+  padding: 5px 9px;
+  background: #fff;
+}
+
+.detail-block {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.meta-list {
+  display: grid;
+  gap: 10px;
+  margin: 0 0 14px;
+}
+
+.meta-list div {
+  display: grid;
+  gap: 4px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
+}
+
+.meta-list dt,
+.meta-list dd {
+  margin: 0;
+}
+
+.subsection {
+  margin-top: 18px;
+}
+
+.banner {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+}
+
+.banner-success {
+  color: var(--success);
+}
+
+.banner-error {
+  color: var(--error);
+}
+
+.form-stack {
+  display: grid;
+  gap: 12px;
+}
+
+button {
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+button:hover {
+  opacity: 0.92;
+}
+
+p {
+  margin: 0;
+}
+
+@media (max-width: 960px) {
+  .summary-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.85rem;
   }
 
-  .dossier-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .summary-grid article:nth-child(2n) {
+    border-right: 0;
   }
 
-  .dossier-card {
-    grid-column: 1 / -1;
-  }
-}
-
-@media (max-width: 900px) {
-  .topbar {
+  .layout {
     grid-template-columns: 1fr;
-  }
-
-  .search-form {
-    grid-column: auto;
-  }
-
-  .workspace-shell {
-    grid-template-columns: 1fr;
-  }
-
-  .left-rail {
-    order: 2;
-  }
-
-  .right-rail {
-    order: 1;
-    grid-template-columns: 1fr;
-  }
-
-  .main-canvas {
-    order: 0;
-  }
-
-  .mission-summary,
-  .worker-grid,
-  .dossier-grid,
-  .board-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .canvas-head {
-    display: grid;
   }
 }
 
 @media (max-width: 640px) {
-  .app-shell {
-    width: min(100%, calc(100% - 0.5rem));
+  .page {
+    width: min(100vw - 20px, 1240px);
+    padding-top: 12px;
   }
 
-  .left-rail {
-    display: none;
+  .masthead,
+  .row-head,
+  .list-row {
+    display: grid;
   }
 
-  .canvas-meta,
-  .mission-stats,
-  .fanout-strip .fanout-group:not(:first-child) {
-    display: none;
-  }
-
-  .mission-summary {
-    gap: 0.45rem;
-  }
-
-  .mission-summary-lower {
-    padding-top: 0.55rem;
-  }
-
-  .worker-grid-list {
+  .summary-grid {
     grid-template-columns: 1fr;
+  }
+
+  .summary-grid article {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .summary-grid article:last-child {
+    border-bottom: 0;
   }
 }

--- a/overlord/templates/index.html
+++ b/overlord/templates/index.html
@@ -7,308 +7,144 @@
     <title>{{ app_name }}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Instrument+Sans:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', path='/styles.css') }}">
   </head>
   <body>
-    <main class="app-shell">
-      <header class="topbar">
-        <div class="brand-block">
+    <main class="page">
+      <header class="masthead">
+        <div>
           <p class="eyebrow">Mission supervision</p>
           <h1>{{ app_name }}</h1>
+          <p class="lede">A quieter view of missions, workers, conflicts, and dispatches.</p>
         </div>
-        <div class="topbar-meta">
-          <span class="meta-pill">{{ environment }}</span>
-          <span class="meta-pill">{{ workspace }}</span>
-          <span class="meta-pill">refresh 15s</span>
+        <div class="masthead-meta">
+          <span>{{ environment }}</span>
+          <span>{{ workspace }}</span>
+          <span>refresh 15s</span>
         </div>
-        <form class="search-form" action="/" method="get">
+      </header>
+
+      <section class="toolbar">
+        <form action="/" method="get" class="search-form">
           <input type="hidden" name="view" value="{{ supervision.current_view }}">
           <input type="hidden" name="saved_view" value="{{ supervision.saved_view }}">
-          <label class="search-box">
+          <label>
             <span class="label">Search</span>
-            <input name="q" value="{{ supervision.search_query }}" placeholder="worker id, repo, branch, blocker, PR">
+            <input name="q" value="{{ supervision.search_query }}" placeholder="worker, repo, branch, blocker, PR">
           </label>
         </form>
-        <nav class="view-switcher" aria-label="Primary views">
+
+        <nav class="tab-row" aria-label="Primary views">
           {% for tab in supervision.view_tabs %}
-          <a class="switch-link{% if tab.selected %} switch-link-selected{% endif %}" href="/?view={{ tab.key }}&saved_view={{ supervision.saved_view }}{% if supervision.search_active %}&q={{ supervision.search_query }}{% endif %}">
+          <a class="tab{% if tab.selected %} tab-selected{% endif %}" href="/?view={{ tab.key }}&saved_view={{ supervision.saved_view }}{% if supervision.search_active %}&q={{ supervision.search_query }}{% endif %}">
             {{ tab.label }}
           </a>
           {% endfor %}
         </nav>
-        <a class="dispatch-cta" href="#dispatch-pane">New Dispatch</a>
-      </header>
 
-      <div class="workspace-shell">
-        <aside class="left-rail">
-          <nav class="rail-nav" aria-label="Sections">
-            <a class="rail-link rail-link-accent" href="/?view=missions&saved_view=needs-attention">Needs Attention</a>
-            <a class="rail-link" href="/?view=missions&saved_view=all-active">All Missions</a>
-            <a class="rail-link" href="/?view=dispatches&saved_view={{ supervision.saved_view }}">Dispatches</a>
-            <a class="rail-link" href="/?view=conflicts&saved_view={{ supervision.saved_view }}">Conflicts</a>
-            <a class="rail-link" href="/?view=workers&saved_view={{ supervision.saved_view }}">Workers</a>
-            <a class="rail-link" href="#settings-panel">Settings</a>
-          </nav>
+        <div class="saved-views">
+          <span class="label">Saved Views</span>
+          <div class="chip-row">
+            {% for view in supervision.saved_views %}
+            <a class="chip{% if view.selected %} chip-selected{% endif %}" href="/?view=missions&saved_view={{ view.key }}{% if supervision.search_active %}&q={{ supervision.search_query }}{% endif %}">
+              {{ view.label }}
+            </a>
+            {% endfor %}
+          </div>
+        </div>
+      </section>
 
-          <section class="rail-panel">
+      <section class="summary-grid">
+        <article>
+          <span class="label">Missions</span>
+          <strong>{{ supervision.summary.missions }}</strong>
+        </article>
+        <article>
+          <span class="label">Workers</span>
+          <strong>{{ supervision.summary.workers }}</strong>
+        </article>
+        <article>
+          <span class="label">Attention</span>
+          <strong>{{ supervision.summary.attention }}</strong>
+        </article>
+        <article>
+          <span class="label">Blocked</span>
+          <strong>{{ supervision.summary.blocked }}</strong>
+        </article>
+        <article>
+          <span class="label">Merge Ready</span>
+          <strong>{{ supervision.summary.merge_ready }}</strong>
+        </article>
+        <article>
+          <span class="label">State</span>
+          <strong><code>{{ data_dir }}/overlord.db</code></strong>
+        </article>
+      </section>
+
+      <div class="layout">
+        <section class="main-pane">
+          {% if supervision.attention_items %}
+          <section class="panel">
             <div class="section-head">
-              <div>
-                <h2>Saved Views</h2>
-                <p>Fast filters for the daily manager loop.</p>
-              </div>
+              <h2>Attention Queue</h2>
+              <p>Only the things likely to need a manager.</p>
             </div>
-            <div class="saved-view-list">
-              {% for view in supervision.saved_views %}
-              <a class="saved-view{% if view.selected %} saved-view-selected{% endif %}" href="/?view=missions&saved_view={{ view.key }}{% if supervision.search_active %}&q={{ supervision.search_query }}{% endif %}">
-                {{ view.label }}
+            <div class="stack">
+              {% for item in supervision.attention_items[:6] %}
+              <a class="list-row" href="/?view=missions&saved_view={{ supervision.saved_view }}&mission={{ item.mission_id }}{% if supervision.search_active %}&q={{ supervision.search_query }}{% endif %}">
+                <div>
+                  <strong>{{ item.label }}</strong>
+                  <p>{{ item.reason }}</p>
+                </div>
+                <span class="muted">{{ item.age }}</span>
               </a>
               {% endfor %}
             </div>
           </section>
+          {% endif %}
 
-          <section class="rail-panel metrics-panel">
-            <div class="metric-block">
-              <span class="label">Missions</span>
-              <strong>{{ supervision.summary.missions }}</strong>
-            </div>
-            <div class="metric-block">
-              <span class="label">Attention</span>
-              <strong>{{ supervision.summary.attention }}</strong>
-            </div>
-            <div class="metric-block">
-              <span class="label">Workers</span>
-              <strong>{{ supervision.summary.workers }}</strong>
-            </div>
-            <div class="metric-block">
-              <span class="label">Merge Ready</span>
-              <strong>{{ supervision.summary.merge_ready }}</strong>
-            </div>
-          </section>
-        </aside>
-
-        <section class="main-canvas">
-          <section class="canvas-head">
-            <div>
-              <p class="eyebrow">Primary canvas</p>
-              <h2>Mission Workspace</h2>
-              <p class="canvas-copy">Scan missions, isolate exceptions, and drill inline before opening a worker dossier.</p>
-            </div>
-            <div class="canvas-meta">
-              <span class="meta-chip">state <code>{{ data_dir }}/overlord.db</code></span>
-              <span class="meta-chip">roots <code>{{ allowed_repo_roots | join(", ") }}</code></span>
-            </div>
-          </section>
-
-          {% if supervision.current_view == "missions" %}
-          <section class="canvas-panel">
-            <div class="section-head section-head-row">
-              <div>
-                <h2>Mission Table</h2>
-                <p>One row per mission, merge ladder separate from execution phase.</p>
-              </div>
-              <span class="section-tag">{{ supervision.saved_view.replace("-", " ") }}</span>
+          {% if supervision.current_view == "missions" or supervision.current_view == "board" or supervision.current_view == "fanout" %}
+          <section class="panel">
+            <div class="section-head">
+              <h2>Mission Table</h2>
+              <p>One mission per row. Merge ladder kept visible, everything else compressed.</p>
             </div>
             {% if supervision.mission_rows %}
-            <div class="mission-table">
+            <div class="stack">
               {% for mission in supervision.mission_rows %}
-              <details class="mission-row{% if mission.selected %} mission-row-selected{% endif %}"{% if mission.selected %} open{% endif %}>
-                <summary>
-                  <div class="mission-summary">
-                    <div class="mission-primary">
-                      <div class="mission-title-row">
-                        <span class="owner-pill">{{ mission.owner }}</span>
-                        <h3>{{ mission.goal }}</h3>
-                      </div>
-                      <p class="repo-line"><strong>{{ mission.repo_name }}</strong> <code>{{ mission.repo_path }}</code></p>
-                    </div>
-                    <div class="mission-stats">
-                      <span><strong>{{ mission.worker_count }}</strong> total</span>
-                      <span><strong>{{ mission.active_workers }}</strong> active</span>
-                      <span><strong>{{ mission.blocked_workers }}</strong> blocked</span>
-                      <span><strong>{{ mission.stale_workers }}</strong> stale</span>
-                      <span><strong>{{ mission.ready_workers }}</strong> ready</span>
-                    </div>
-                    <div class="mission-recency">
-                      <span class="label">Latest event</span>
-                      <strong>{{ mission.latest_event_label }}</strong>
-                    </div>
-                    <div class="mission-merge">
-                      <span class="label">Merge ladder</span>
-                      <strong>{{ mission.merge_summary }}</strong>
-                    </div>
+              <article class="mission-row{% if mission.selected %} mission-row-selected{% endif %}">
+                <div class="row-head">
+                  <div>
+                    <h3>{{ mission.goal }}</h3>
+                    <p class="muted">{{ mission.repo_name }} · <code>{{ mission.repo_path }}</code></p>
                   </div>
-                  <div class="mission-summary-lower">
-                    <div class="badge-row">
-                      {% for badge in mission.exception_badges %}
-                      <span class="badge badge-{{ badge.tone }}">{{ badge.label }}</span>
-                      {% endfor %}
-                      <span class="badge badge-status">{{ mission.status_label }}</span>
-                    </div>
-                    <div class="fanout-strip">
-                      {% for group in mission.fanout_strip %}
-                      <div class="fanout-group">
-                        <span class="fanout-label">{{ group.label }}</span>
-                        <div class="fanout-workers">
-                          {% for worker in group.workers %}
-                          <span class="worker-chip worker-chip-{{ worker.freshness_state }}">{{ worker.worker_id }}</span>
-                          {% endfor %}
-                          {% if group.overflow %}
-                          <span class="worker-chip worker-chip-overflow">+{{ group.overflow }} more</span>
-                          {% endif %}
-                        </div>
-                      </div>
-                      {% endfor %}
-                    </div>
-                  </div>
-                </summary>
-
-                <div class="mission-detail">
-                  <div class="worker-grid">
-                    <section class="detail-card">
-                      <div class="section-head">
-                        <div>
-                          <h3>Worker Fanout</h3>
-                          <p>Grouped workers with direct manager drilldown.</p>
-                        </div>
-                      </div>
-                      <div class="worker-grid-list">
-                        {% for worker in mission.workers %}
-                        <a class="worker-tile worker-tile-{{ worker.freshness_state }}{% if worker.selected %} worker-tile-selected{% endif %}" href="/?view=missions&saved_view={{ supervision.saved_view }}&mission={{ mission.id }}&worker={{ worker.worker_id }}{% if supervision.search_active %}&q={{ supervision.search_query }}{% endif %}">
-                          <div class="worker-tile-head">
-                            <strong>{{ worker.worker_id }}</strong>
-                            <span class="badge badge-merge">{{ worker.merge_label }}</span>
-                          </div>
-                          <p>{{ worker.status_line }}</p>
-                          <p class="subtle">{{ worker.phase_label }} · {{ worker.updated_label }}</p>
-                          {% if worker.blocker %}
-                          <p class="blocker-line">{{ worker.blocker }}</p>
-                          {% endif %}
-                          {% if worker.branch %}
-                          <p class="mono-line"><code>{{ worker.branch }}</code></p>
-                          {% endif %}
-                        </a>
-                        {% endfor %}
-                      </div>
-                    </section>
-
-                    <section class="detail-card">
-                      <div class="section-head">
-                        <div>
-                          <h3>Mission Timeline</h3>
-                          <p>Compressed supervision events only.</p>
-                        </div>
-                      </div>
-                      {% if mission.timeline %}
-                      <div class="timeline-list">
-                        {% for event in mission.timeline %}
-                        <article class="timeline-entry">
-                          <div class="timeline-top">
-                            <span class="badge badge-status">{{ event.label }}</span>
-                            <span class="subtle">{{ event.timestamp | relative_time }}</span>
-                          </div>
-                          <p>{{ event.summary }}</p>
-                          {% if event.worker_id %}
-                          <p class="mono-line"><code>{{ event.worker_id }}</code></p>
-                          {% endif %}
-                        </article>
-                        {% endfor %}
-                      </div>
-                      {% else %}
-                      <p class="empty-state">No mission events yet.</p>
-                      {% endif %}
-                    </section>
-                  </div>
-
-                  {% if mission.selected and selected_worker %}
-                  <div class="dossier-grid">
-                    <section class="detail-card dossier-card">
-                      <div class="section-head">
-                        <div>
-                          <h3>Worker Dossier</h3>
-                          <p>Current state, next irreversible step, blocker, and merge posture.</p>
-                        </div>
-                      </div>
-                      <div class="dossier-head">
-                        <div>
-                          <p class="eyebrow">{{ selected_worker.phase.value }}</p>
-                          <h3>{{ selected_worker.worker_id }}</h3>
-                        </div>
-                        <span class="badge badge-{{ supervision.worker_states[selected_worker.worker_id].state }}">{{ supervision.worker_states[selected_worker.worker_id].label }}</span>
-                      </div>
-                      <p>{{ selected_worker.status_line }}</p>
-                      <div class="dossier-meta">
-                        <div><span class="label">Repo</span><p><code>{{ selected_worker.repo_path }}</code></p></div>
-                        <div><span class="label">Branch</span><p>{% if selected_worker.branch %}<code>{{ selected_worker.branch }}</code>{% else %}none{% endif %}</p></div>
-                        <div><span class="label">Worktree</span><p>{% if selected_worker.worktree %}<code>{{ selected_worker.worktree }}</code>{% else %}none{% endif %}</p></div>
-                        <div><span class="label">Artifact</span><p>{% if selected_worker.owned_artifact %}<code>{{ selected_worker.owned_artifact }}</code>{% else %}none{% endif %}</p></div>
-                      </div>
-                      {% if selected_worker.next_irreversible_step %}
-                      <p class="next-step"><strong>Next irreversible step</strong> {{ selected_worker.next_irreversible_step }}</p>
-                      {% endif %}
-                      {% if selected_worker.blocker %}
-                      <p class="blocker-line"><strong>Blocker</strong> {{ selected_worker.blocker }}</p>
-                      {% endif %}
-                      {% if selected_worker.pr_url %}
-                      <p><a href="{{ selected_worker.pr_url }}">Open PR</a></p>
-                      {% endif %}
-                    </section>
-
-                    <section class="detail-card">
-                      <div class="section-head">
-                        <div>
-                          <h3>Worker Timeline</h3>
-                          <p>State transitions kept separate from notes.</p>
-                        </div>
-                      </div>
-                      <div class="timeline-list">
-                        {% for transition in selected_worker.transitions[:8] %}
-                        <article class="timeline-entry">
-                          <div class="timeline-top">
-                            <span class="badge badge-status">{{ transition.current_phase.value }}</span>
-                            <span class="subtle">{{ timestamp_format(transition.created_at) }}</span>
-                          </div>
-                          <p>{{ transition.status_line }}</p>
-                          {% if transition.next_irreversible_step %}
-                          <p class="next-step"><strong>Next</strong> {{ transition.next_irreversible_step }}</p>
-                          {% endif %}
-                          {% if transition.note %}
-                          <p class="subtle">{{ transition.note }}</p>
-                          {% endif %}
-                        </article>
-                        {% endfor %}
-                      </div>
-                    </section>
-
-                    <section class="detail-card">
-                      <div class="section-head">
-                        <div>
-                          <h3>Phase Notes</h3>
-                          <p>High-signal notes by lifecycle phase.</p>
-                        </div>
-                      </div>
-                      {% if selected_phase_notes %}
-                      <div class="phase-note-groups">
-                        {% for group in selected_phase_notes %}
-                        <article class="phase-note-group">
-                          <div class="timeline-top">
-                            <span class="badge badge-status">{{ group.phase.value }}</span>
-                            <span class="subtle">{{ group.notes | length }} notes</span>
-                          </div>
-                          {% for note in group.notes[:3] %}
-                          <p>{{ note.note }}</p>
-                          {% endfor %}
-                        </article>
-                        {% endfor %}
-                      </div>
-                      {% else %}
-                      <p class="empty-state">No phase notes yet.</p>
-                      {% endif %}
-                    </section>
-                  </div>
-                  {% endif %}
+                  <span class="status">{{ mission.status_label }}</span>
                 </div>
-              </details>
+                <p class="muted">owner {{ mission.owner }} · {{ mission.latest_event_label }} · merge ladder {{ mission.merge_summary }}</p>
+                <div class="chip-row">
+                  <span class="chip">{{ mission.worker_count }} workers</span>
+                  {% if mission.blocked_workers %}
+                  <span class="chip">{{ mission.blocked_workers }} blocked</span>
+                  {% endif %}
+                  {% if mission.stale_workers %}
+                  <span class="chip">{{ mission.stale_workers }} stale</span>
+                  {% endif %}
+                  {% if mission.ready_workers %}
+                  <span class="chip">{{ mission.ready_workers }} ready</span>
+                  {% endif %}
+                  {% for badge in mission.exception_badges %}
+                  <span class="chip">{{ badge.label }}</span>
+                  {% endfor %}
+                </div>
+                <div class="worker-links">
+                  {% for worker in mission.workers %}
+                  <a href="/?view=missions&saved_view={{ supervision.saved_view }}&mission={{ mission.id }}&worker={{ worker.worker_id }}{% if supervision.search_active %}&q={{ supervision.search_query }}{% endif %}">
+                    {{ worker.worker_id }}
+                  </a>
+                  {% endfor %}
+                </div>
+              </article>
               {% endfor %}
             </div>
             {% else %}
@@ -317,84 +153,48 @@
           </section>
           {% endif %}
 
-          {% if supervision.current_view == "board" %}
-          <section class="canvas-panel">
+          {% if supervision.current_view == "workers" %}
+          <section class="panel">
             <div class="section-head">
-              <div>
-                <h2>Mission Board</h2>
-                <p>Operational grouping by supervision outcome.</p>
-              </div>
+              <h2>Workers</h2>
+              <p>Flat worker list when you want direct selection.</p>
             </div>
-            <div class="board-grid">
-              {% for column in supervision.mission_board %}
-              <section class="board-column">
-                <div class="board-head">
-                  <h3>{{ column.label }}</h3>
-                  <span class="meta-pill">{{ column.missions | length }}</span>
+            {% if supervision.worker_rows %}
+            <div class="stack">
+              {% for worker in supervision.worker_rows %}
+              <a class="list-row" href="/?view=workers&saved_view={{ supervision.saved_view }}&mission={{ worker.mission_id }}&worker={{ worker.worker_id }}{% if supervision.search_active %}&q={{ supervision.search_query }}{% endif %}">
+                <div>
+                  <strong>{{ worker.worker_id }}</strong>
+                  <p>{{ worker.status_line }}</p>
+                  <p class="muted">{{ worker.repo_name }} · {{ worker.phase_label }} · {{ worker.updated_label }}</p>
                 </div>
-                {% for mission in column.missions %}
-                <a class="board-card" href="/?view=missions&saved_view={{ supervision.saved_view }}&mission={{ mission.id }}">
-                  <strong>{{ mission.goal }}</strong>
-                  <p>{{ mission.repo_name }} · {{ mission.owner }}</p>
-                  <p class="subtle">{{ mission.merge_summary }}</p>
-                </a>
-                {% endfor %}
-              </section>
+                <span class="status">{{ worker.merge_label }}</span>
+              </a>
               {% endfor %}
             </div>
-          </section>
-          {% endif %}
-
-          {% if supervision.current_view == "fanout" %}
-          <section class="canvas-panel">
-            <div class="section-head">
-              <div>
-                <h2>Fanout Map</h2>
-                <p>Compact mission clusters by phase, not a graph-first home screen.</p>
-              </div>
-            </div>
-            <div class="fanout-map">
-              {% for cluster in supervision.fanout_clusters %}
-              <article class="fanout-card">
-                <div class="board-head">
-                  <strong>{{ cluster.repo_name }}</strong>
-                  <span class="badge badge-status">{{ cluster.status_label }}</span>
-                </div>
-                <p>{{ cluster.goal }}</p>
-                <p class="subtle">{{ cluster.owner }} · {{ cluster.worker_count }} workers</p>
-                <div class="phase-pill-row">
-                  {% for phase in cluster.phase_counts %}
-                  <span class="meta-chip">{{ phase.label }}: {{ phase.count }}</span>
-                  {% endfor %}
-                </div>
-              </article>
-              {% endfor %}
-            </div>
+            {% else %}
+            <p class="empty-state">No workers match the current filter.</p>
+            {% endif %}
           </section>
           {% endif %}
 
           {% if supervision.current_view == "dispatches" %}
-          <section class="canvas-panel">
+          <section class="panel">
             <div class="section-head">
-              <div>
-                <h2>Dispatch Log</h2>
-                <p>Intent, owner, repo, launch context, and inferred mission progress.</p>
-              </div>
+              <h2>Dispatch</h2>
+              <p>Recent general orders and where their logs live.</p>
             </div>
             {% if supervision.dispatch_rows %}
-            <div class="list-table">
-              {% for dispatch in supervision.dispatch_rows %}
-              <article class="list-row">
+            <div class="stack">
+              {% for row in supervision.dispatch_rows %}
+              <article class="list-row list-row-static">
                 <div>
-                  <strong>{{ dispatch.objective }}</strong>
-                  <p class="subtle">{{ dispatch.owner }} · {{ dispatch.repo_name }} · {{ dispatch.progress }}</p>
+                  <strong>{{ row.objective }}</strong>
+                  <p>{{ row.owner }} · {{ row.repo_name }}{% if row.branch_hint %} · <code>{{ row.branch_hint }}</code>{% endif %}</p>
+                  <p class="muted">pid {{ row.pid }} · {{ timestamp_format(row.launch_time) }}</p>
+                  <p class="muted"><code>{{ row.log_path }}</code></p>
                 </div>
-                <div class="list-meta">
-                  {% if dispatch.branch_hint %}<span class="meta-chip"><code>{{ dispatch.branch_hint }}</code></span>{% endif %}
-                  <span class="meta-chip"><code>{{ dispatch.prompt_path }}</code></span>
-                  <span class="meta-chip"><code>{{ dispatch.log_path }}</code></span>
-                  <span class="meta-chip">pid {{ dispatch.pid }}</span>
-                </div>
+                <span class="status">{{ row.progress }}</span>
               </article>
               {% endfor %}
             </div>
@@ -405,109 +205,111 @@
           {% endif %}
 
           {% if supervision.current_view == "conflicts" %}
-          <section class="canvas-panel">
+          <section class="panel">
             <div class="section-head">
-              <div>
-                <h2>Conflicts</h2>
-                <p>Grouped by mission first, then repo path, branch, worktree, and artifact collisions.</p>
-              </div>
+              <h2>Conflicts</h2>
+              <p>Shared branch or artifact collisions.</p>
             </div>
             {% if supervision.conflict_groups %}
-            <div class="list-table">
+            <div class="stack">
               {% for group in supervision.conflict_groups %}
-              <article class="conflict-group">
-                <div class="board-head">
+              <article class="list-row list-row-static">
+                <div>
                   <strong>{{ group.goal }}</strong>
-                  <span class="meta-pill">{{ group.repo_name }}</span>
+                  <p>{{ group.repo_name }}</p>
+                  {% for conflict in group.conflicts %}
+                  <p class="muted">{{ conflict.kind }} · <code>{{ conflict.value }}</code> · {{ conflict.worker_ids | join(", ") }}</p>
+                  {% endfor %}
                 </div>
-                {% for conflict in group.conflicts %}
-                <div class="conflict-item">
-                  <p><strong>{{ conflict.field }}</strong> <code>{{ conflict.value }}</code></p>
-                  <p class="subtle">{{ conflict.worker_ids | join(", ") }}</p>
-                </div>
-                {% endfor %}
               </article>
               {% endfor %}
             </div>
             {% else %}
-            <p class="empty-state">No active ownership conflicts.</p>
-            {% endif %}
-          </section>
-          {% endif %}
-
-          {% if supervision.current_view == "workers" %}
-          <section class="canvas-panel">
-            <div class="section-head">
-              <div>
-                <h2>Worker Roster</h2>
-                <p>Lifecycle visible in a flat scan when needed.</p>
-              </div>
-            </div>
-            {% if supervision.worker_rows %}
-            <div class="list-table">
-              {% for worker in supervision.worker_rows %}
-              <a class="list-row" href="/?view=missions&saved_view={{ supervision.saved_view }}&mission={{ worker.mission_id }}&worker={{ worker.worker_id }}">
-                <div>
-                  <strong>{{ worker.worker_id }}</strong>
-                  <p class="subtle">{{ worker.mission_owner }} · {{ worker.mission_goal }}</p>
-                </div>
-                <div class="list-meta">
-                  <span class="badge badge-status">{{ worker.phase_label }}</span>
-                  <span class="badge badge-{{ worker.freshness_state }}">{{ worker.updated_label }}</span>
-                  <span class="badge badge-merge">{{ worker.merge_label }}</span>
-                  <span class="meta-chip"><code>{{ worker.repo_name }}</code></span>
-                </div>
-              </a>
-              {% endfor %}
-            </div>
-            {% else %}
-            <p class="empty-state">No workers tracked yet.</p>
+            <p class="empty-state">No conflicts in the current view.</p>
             {% endif %}
           </section>
           {% endif %}
         </section>
 
-        <aside class="right-rail">
-          <section class="rail-panel">
+        <aside class="side-pane">
+          <section class="panel">
             <div class="section-head">
-              <div>
-                <h2>Attention Queue</h2>
-                <p>Manager-only exceptions sorted for action.</p>
+              <h2>Worker Detail</h2>
+              <p>Selected worker plus recent history.</p>
+            </div>
+            {% if selected_worker %}
+            <div class="detail-block">
+              <p class="eyebrow">{{ selected_worker.phase.value }}</p>
+              <h3>{{ selected_worker.worker_id }}</h3>
+              <p>{{ selected_worker.status_line }}</p>
+            </div>
+            <dl class="meta-list">
+              <div><dt>Repo</dt><dd><code>{{ selected_worker.repo_path }}</code></dd></div>
+              <div><dt>Branch</dt><dd>{% if selected_worker.branch %}<code>{{ selected_worker.branch }}</code>{% else %}none{% endif %}</dd></div>
+              <div><dt>Worktree</dt><dd>{% if selected_worker.worktree %}<code>{{ selected_worker.worktree }}</code>{% else %}none{% endif %}</dd></div>
+              <div><dt>Artifact</dt><dd>{% if selected_worker.owned_artifact %}<code>{{ selected_worker.owned_artifact }}</code>{% else %}none{% endif %}</dd></div>
+            </dl>
+            {% if selected_worker.next_irreversible_step %}
+            <p><strong>Next</strong> {{ selected_worker.next_irreversible_step }}</p>
+            {% endif %}
+            {% if selected_worker.blocker %}
+            <p><strong>Blocker</strong> {{ selected_worker.blocker }}</p>
+            {% endif %}
+            {% if selected_worker.pr_url %}
+            <p><a href="{{ selected_worker.pr_url }}">Open PR</a></p>
+            {% endif %}
+
+            <div class="subsection">
+              <h3>Timeline</h3>
+              <div class="stack compact-stack">
+                {% for transition in selected_worker.transitions[:8] %}
+                <article class="timeline-item">
+                  <p><strong>{{ transition.current_phase.value }}</strong> · {{ timestamp_format(transition.created_at) }}</p>
+                  <p>{{ transition.status_line }}</p>
+                  {% if transition.note %}
+                  <p class="muted">{{ transition.note }}</p>
+                  {% endif %}
+                </article>
+                {% endfor %}
               </div>
             </div>
-            {% if supervision.attention_items %}
-            <div class="attention-list">
-              {% for item in supervision.attention_items %}
-              <a class="attention-item" href="/?view=missions&saved_view=needs-attention&mission={{ item.mission_id }}">
-                <div class="timeline-top">
-                  <span class="badge badge-{{ item.kind }}">{{ item.label }}</span>
-                  <span class="subtle">{{ item.age }}</span>
-                </div>
-                <p>{{ item.reason }}</p>
-              </a>
-              {% endfor %}
+
+            <div class="subsection">
+              <h3>Phase Notes</h3>
+              {% if selected_phase_notes %}
+              <div class="stack compact-stack">
+                {% for group in selected_phase_notes %}
+                <article class="timeline-item">
+                  <p><strong>{{ group.phase.value }}</strong></p>
+                  {% for note in group.notes[:3] %}
+                  <p>{{ note.note }}</p>
+                  {% endfor %}
+                </article>
+                {% endfor %}
+              </div>
+              {% else %}
+              <p class="empty-state">No phase notes yet.</p>
+              {% endif %}
             </div>
             {% else %}
-            <p class="empty-state">Nothing needs action right now.</p>
+            <p class="empty-state">No worker selected.</p>
             {% endif %}
           </section>
 
-          <section class="rail-panel" id="dispatch-pane">
+          <section class="panel" id="dispatch-pane">
             <div class="section-head">
-              <div>
-                <h2>Dispatch</h2>
-                <p>Compact launch surface for new delegated work.</p>
-              </div>
+              <h2>Dispatch</h2>
+              <p>Launch a general order.</p>
             </div>
             {% if dispatch_status == "launched" %}
-            <div class="banner banner-success"><strong>Launched.</strong> Dispatch logged under <code>data/dispatches</code>.</div>
+            <p class="banner banner-success">Launched. Prompt and logs were recorded under the configured data dir.</p>
             {% endif %}
             {% if dispatch_error %}
-            <div class="banner banner-error"><strong>Rejected.</strong> {{ dispatch_error }}</div>
+            <p class="banner banner-error">Rejected. {{ dispatch_error }}</p>
             {% endif %}
-            <form class="compact-form" action="/dispatch" method="post">
+            <form class="form-stack" action="/dispatch" method="post">
               <label>
-                <span class="label">Owner</span>
+                <span class="label">General Worker ID</span>
                 <input name="general_worker_id" value="{{ dispatch_defaults.general_worker_id }}" required>
               </label>
               <label>
@@ -519,73 +321,102 @@
                 <input name="branch_hint" value="{{ dispatch_defaults.branch_hint }}">
               </label>
               <label>
-                <span class="label">Objective</span>
-                <textarea name="operator_instruction" rows="5" required placeholder="Ship the mission-first supervision rewrite, verify with pytest, and return the PR URL."></textarea>
+                <span class="label">Operator Instruction</span>
+                <textarea name="operator_instruction" rows="5" required></textarea>
               </label>
-              <button type="submit">Launch Dispatch</button>
+              <button type="submit">Launch General</button>
             </form>
-            {% if recent_commands %}
-            <div class="timeline-list">
-              {% for command in recent_commands[:4] %}
-              <article class="timeline-entry">
-                <div class="timeline-top">
-                  <span class="badge badge-status">{{ command.general_worker_id }}</span>
-                  <span class="subtle">{{ command.created_at | relative_time }}</span>
-                </div>
-                <p>{{ command.operator_instruction }}</p>
-                <p class="mono-line"><code>{{ command.repo_path }}</code></p>
-                <p class="mono-line"><code>{{ command.log_path }}</code></p>
-              </article>
-              {% endfor %}
+            {% if supervision.dispatch_rows %}
+            <div class="subsection">
+              <h3>Recent Dispatches</h3>
+              <div class="stack compact-stack">
+                {% for row in supervision.dispatch_rows[:3] %}
+                <article class="timeline-item">
+                  <p><strong>{{ row.owner }}</strong></p>
+                  <p>{{ row.objective }}</p>
+                  <p class="muted"><code>{{ row.log_path }}</code></p>
+                </article>
+                {% endfor %}
+              </div>
             </div>
             {% endif %}
           </section>
 
-          <section class="rail-panel">
+          <section class="panel" id="self-report">
             <div class="section-head">
-              <div>
-                <h2>Self Report Intake</h2>
-                <p>Manual worker updates still available.</p>
-              </div>
+              <h2>Self Report Intake</h2>
+              <p>One worker transition at a time.</p>
             </div>
             {% if report_status == "accepted" %}
-            <div class="banner banner-success"><strong>Accepted.</strong> Worker update accepted.</div>
+            <p class="banner banner-success">Accepted. The board will update on refresh.</p>
             {% endif %}
             {% if report_error %}
-            <div class="banner banner-error"><strong>Rejected.</strong> {{ report_error }}</div>
+            <p class="banner banner-error">Rejected. {{ report_error }}</p>
             {% endif %}
-            <form class="compact-form" action="/report" method="post">
-              <label><span class="label">Worker ID</span><input name="worker_id" value="{{ report_defaults.worker_id }}" required></label>
-              <label><span class="label">Worker Token</span><input name="worker_token" type="password" required></label>
-              <div class="split-fields">
-                <label><span class="label">Current Phase</span><select name="current_phase">{% for phase_value in phase_values %}<option value="{{ phase_value }}"{% if report_defaults.current_phase == phase_value %} selected{% endif %}>{{ phase_value }}</option>{% endfor %}</select></label>
-                <label><span class="label">Previous Phase</span><select name="previous_phase"><option value="">none</option>{% for phase_value in phase_values %}<option value="{{ phase_value }}"{% if report_defaults.previous_phase == phase_value %} selected{% endif %}>{{ phase_value }}</option>{% endfor %}</select></label>
-              </div>
-              <label><span class="label">Status Line</span><input name="status_line" required></label>
-              <label><span class="label">Repo Path</span><input name="repo_path" value="{{ report_defaults.repo_path }}" required></label>
-              <label><span class="label">Branch</span><input name="branch" value="{{ report_defaults.branch }}"></label>
-              <label><span class="label">Worktree</span><input name="worktree" value="{{ report_defaults.worktree }}"></label>
-              <label><span class="label">Owned Artifact</span><input name="owned_artifact" value="{{ report_defaults.owned_artifact }}"></label>
-              <label><span class="label">Next Irreversible Step</span><input name="next_irreversible_step"></label>
-              <label><span class="label">Blocker</span><input name="blocker"></label>
-              <label><span class="label">Pull Request URL</span><input name="pr_url" type="url"></label>
-              <label><span class="label">Short Note</span><textarea name="note" rows="3"></textarea></label>
-              <button type="submit">Post Report</button>
+            <form class="form-stack" action="/report" method="post">
+              <label>
+                <span class="label">Worker ID</span>
+                <input name="worker_id" value="{{ report_defaults.worker_id }}" required>
+              </label>
+              <label>
+                <span class="label">Worker Token</span>
+                <input name="worker_token" type="password" required>
+              </label>
+              <label>
+                <span class="label">Current Phase</span>
+                <select name="current_phase" required>
+                  {% for phase_value in phase_values %}
+                  <option value="{{ phase_value }}"{% if report_defaults.current_phase == phase_value %} selected{% endif %}>{{ phase_value }}</option>
+                  {% endfor %}
+                </select>
+              </label>
+              <label>
+                <span class="label">Previous Phase</span>
+                <select name="previous_phase">
+                  <option value="">none</option>
+                  {% for phase_value in phase_values %}
+                  <option value="{{ phase_value }}"{% if report_defaults.previous_phase == phase_value %} selected{% endif %}>{{ phase_value }}</option>
+                  {% endfor %}
+                </select>
+              </label>
+              <label>
+                <span class="label">Status Line</span>
+                <input name="status_line" required>
+              </label>
+              <label>
+                <span class="label">Repo Path</span>
+                <input name="repo_path" value="{{ report_defaults.repo_path }}" required>
+              </label>
+              <label>
+                <span class="label">Branch</span>
+                <input name="branch" value="{{ report_defaults.branch }}">
+              </label>
+              <label>
+                <span class="label">Worktree</span>
+                <input name="worktree" value="{{ report_defaults.worktree }}">
+              </label>
+              <label>
+                <span class="label">Owned Artifact</span>
+                <input name="owned_artifact" value="{{ report_defaults.owned_artifact }}">
+              </label>
+              <label>
+                <span class="label">Next Irreversible Step</span>
+                <input name="next_irreversible_step">
+              </label>
+              <label>
+                <span class="label">Blocker</span>
+                <input name="blocker">
+              </label>
+              <label>
+                <span class="label">Pull Request URL</span>
+                <input name="pr_url" type="url">
+              </label>
+              <label>
+                <span class="label">Short Note</span>
+                <textarea name="note" rows="4"></textarea>
+              </label>
+              <button type="submit">Post Self Report</button>
             </form>
-          </section>
-
-          <section class="rail-panel" id="settings-panel">
-            <div class="section-head">
-              <div>
-                <h2>Settings</h2>
-                <p>Static environment context for this localhost control plane.</p>
-              </div>
-            </div>
-            <div class="settings-list">
-              <p><strong>Environment</strong> {{ environment }}</p>
-              <p><strong>Workspace</strong> {{ workspace }}</p>
-              <p><strong>Allowlist</strong> <code>{{ allowed_repo_roots | join(", ") }}</code></p>
-            </div>
           </section>
         </aside>
       </div>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -131,15 +131,13 @@ def test_homepage_renders_live_dashboard(tmp_path: Path) -> None:
 
     assert response.status_code == 200
     assert "Mission supervision" in response.text
-    assert "Mission Workspace" in response.text
     assert "Mission Table" in response.text
-    assert "Attention Queue" in response.text
     assert "worker-123" in response.text
-    assert "Worker Dossier" in response.text
+    assert "Worker Detail" in response.text
     assert "merge ladder" in response.text.lower()
     assert "Self Report Intake" in response.text
     assert "Dispatch" in response.text
-    assert "Mission Timeline" in response.text
+    assert "Timeline" in response.text
     assert "Phase Notes" in response.text
     assert "keeping api and persistence untouched" in response.text
 


### PR DESCRIPTION
## Summary
- replace the dense mission-control presentation with a much quieter minimal layout
- keep search, worker selection, conflicts, dispatches, and self-report flows available in reduced form
- update UI assertions to match the simplified dashboard copy

## Verification
- /Users/matthewschwartz/.venvs/overlord/bin/pytest -q